### PR TITLE
Exposition of the parallel-distance-matrix.cpp Gallery Entry

### DIFF
--- a/inst/examples/parallel-distance-matrix.cpp
+++ b/inst/examples/parallel-distance-matrix.cpp
@@ -167,7 +167,7 @@ struct JsDistance : public Worker {
    
    // initialize from Rcpp input and output matrixes (the RMatrix class
    // can be automatically converted to from the Rcpp matrix type)
-   JsDistance(NumericMatrix mat, NumericMatrix rmat, )
+   JsDistance(NumericMatrix mat, NumericMatrix rmat)
       : mat(mat), rmat(rmat) {}
    
    // function call operator that work for the specified range (begin/end)


### PR DESCRIPTION
Here is an edited parallel-distance-matrix.cpp with background text, comments and benchmarking code to demonstrate the use of RcppParallel on row-based computations. 

At the moment, this code demonstrates how one could use almost any distance metric by editing/adding additional parallel workers. One refinement of this code would be to take a distance kernel in the parallel worker constructor.
