### PR TITLE
Add support for TBB on Solaris

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ RcppParallel 4.3.7
 * Fix failure to compile with Rtools 3.3
 * Fix failure to compile on OS X Snow Leopard R toolchain
 * Add tbbmalloc library
+* Add support for TBB on Solaris
 
 RcppParallel 4.3.6
 ------------------------------------------------------------------------

--- a/R/build.R
+++ b/R/build.R
@@ -36,8 +36,8 @@ tbbCxxFlags <- function() {
 
 # Return the linker flags requried for TBB on this platform
 tbbLdFlags <- function() {
-   # on Windows we need to explicitly link against tbb.dll
-   if (Sys.info()['sysname'] == "Windows") {
+   # on Windows and Solaris we need to explicitly link against tbb.dll
+   if (Sys.info()['sysname'] %in% c("Windows", "SunOS")) {
       tbb <- tbbLibPath()
       paste("-L", asBuildPath(dirname(tbb)), " -ltbb -ltbbmalloc", sep = "")
    } else {
@@ -51,7 +51,8 @@ tbbLibPath <- function(suffix = "") {
    tbbSupported <- list(
       "Darwin" = paste("libtbb", suffix, ".dylib", sep = ""), 
       "Linux" = paste("libtbb", suffix, ".so.2", sep = ""), 
-      "Windows" = paste("tbb", suffix, ".dll", sep = "") 
+      "Windows" = paste("tbb", suffix, ".dll", sep = ""),
+      "SunOS" = paste("libtbb", suffix, ".so", sep = "")
    )
    if (sysname %in% names(tbbSupported)) {
       libDir <- "lib/"

--- a/inst/include/RcppParallel.h
+++ b/inst/include/RcppParallel.h
@@ -10,7 +10,7 @@
 // compatibility with CRAN packages not previously configured
 // to link to TBB in Makevars.win)
 #ifndef RCPP_PARALLEL_USE_TBB
-#if defined(__APPLE__) || defined(__gnu_linux__)
+#if defined(__APPLE__) || defined(__gnu_linux__) || ((defined(__sun) && defined(__SVR4)))
 #define RCPP_PARALLEL_USE_TBB 1
 #include "RcppParallel/TBB.h"
 #else

--- a/inst/include/tthread/tinythread.h
+++ b/inst/include/tthread/tinythread.h
@@ -81,6 +81,7 @@ freely, subject to the following restrictions:
   #include <signal.h>
   #include <sched.h>
   #include <unistd.h>
+  #include <stdlib.h> 
 #endif
 
 // Generic includes

--- a/src/Makevars
+++ b/src/Makevars
@@ -23,6 +23,9 @@ else
     USE_TBB=Linux
     CXX_STD = CXX11
   endif
+  ifeq ($(UNAME), SunOS)
+    USE_TBB=SunOS
+  endif
   # Note: regular MinGW not supported
 
 endif
@@ -55,6 +58,13 @@ ifeq ($(USE_TBB),  Windows)
   # "undefined reference to `tbb::task_scheduler_init::terminate()'"
   PKG_LIBS += -L../inst/lib/$(ARCH_DIR) -ltbb -ltbbmalloc
 
+endif
+
+ifeq ($(USE_TBB),  SunOS)
+   R_32BIT = $(shell ${R_HOME}/bin/Rscript -e 'cat(.Machine$$sizeof.pointer == 4)')
+   ifeq ($(R_32BIT), TRUE)
+      MAKE_ARGS += arch=ia32
+   endif
 endif
 
 .PHONY: all tbb

--- a/src/tbb/build/SunOS.suncc.inc
+++ b/src/tbb/build/SunOS.suncc.inc
@@ -31,7 +31,7 @@ WARNING_AS_ERROR_KEY = Warning as error
 WARNING_SUPPRESS = -erroff=unassigned,attrskipunsup,badargtype2w,badbinaryopw,wbadasg,wvarhidemem,inlasmpnu
 tbb_strict=0
 
-CPLUS = CC
+CPLUS = CC -library=stlport4
 CONLY = cc
 LIB_LINK_FLAGS = -G -R . -M$(tbb_root)/build/suncc.map.pause
 LINK_FLAGS += -M$(tbb_root)/build/suncc.map.pause


### PR DESCRIPTION
Add Solaris to the whitelist of supported platforms for TBB. 

Note that this is not yet tested (because I don't have a working Solaris configuration) so should not be merged.
