### PR TITLE
Bugfix/unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
-  - ./travis-tool.sh github_package hadley/testthat
+  #- ./travis-tool.sh github_package hadley/testthat
   - ./travis-tool.sh github_package RcppCore/Rcpp
+  - ./travis-tool.sh install_aptget r-cran-runit
 
 script: 
   - R CMD INSTALL .

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ before_install:
 
 script: 
   - R CMD INSTALL .
-  - cd tests
-  - Rscript testthat.R
+  - cd tests && Rscript doRUnit.R
 
 notifications:
   email:


### PR DESCRIPTION
Here is a pretty trivial PR as I noticed that the final command in Travis failed -- looks like a copy&paste job from a testthat package, but this one uses RUnit ...

Also see line 8 below -- we could also Rcpp via r-cran-rcpp which gets us the most recent release (via Michael's PPA).  I do that in most of my Travis scripts as it saves a few seconds...