### PR TITLE
Work around M_ARCH issue

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -6,7 +6,7 @@ ifeq ($(OS), Windows_NT)
   USE_TBB=Windows
   TBB_COPY_PATTERN=tbb*.dll
   
-  MAKE_CMD = PATH="$(shell cygpath $(dir $(CC))):$(PATH)" make
+  MAKE_CMD = PATH="$(shell cygpath $(dir $(firstword $(CC)))):$(PATH)" make
 
 else
   
@@ -70,9 +70,9 @@ all: tbb $(SHLIB)
 tbb:
 	mkdir -p ../inst/lib/$(ARCH_DIR); \
 	cd tbb/src; \
-	if [[ "$(CC)" == clang* ]]; then \
+	if [ "$(CC)" = clang* ]; then \
 	   $(MAKE_CMD) cpp0x=1 compiler=clang $(MAKE_ARGS); \
-	elif [[ "$(CC)" == *gcc* ]]; then \
+	elif [ "$(CC)" = *gcc* ]; then \
 	   $(MAKE_CMD) cpp0x=1 compiler=gcc $(MAKE_ARGS); \
 	else \
 	   $(MAKE_CMD) cpp0x=1 $(MAKE_ARGS); \


### PR DESCRIPTION
if M_ARCH is set it will be appended to CC, e.g.
`C:/path_to_rtools/mingw_64/gcc -m64`

This also uses `[` rather than `[[` which while not strictly POSIX
complaint due to the `*` seems to work on Windows and OS X without issue.