### PR TITLE
explicitly set CC, CXX for TBB makefiles

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -6,7 +6,7 @@ ifeq ($(OS), Windows_NT)
   USE_TBB=Windows
   TBB_COPY_PATTERN=tbb*.dll
   
-  MAKE_CMD = PATH="$(shell cygpath $(dir $(CC))):$(PATH)" make
+  MAKE_CMD = CONLY="$(CC)" CPLUS="$(CXX1X)" make
 
 else
   
@@ -41,10 +41,10 @@ ifeq ($(USE_TBB),  Windows)
   # compiler: overwrite default (which is cl = MS compiler)
   MAKE_ARGS += rtools=true compiler=gcc
   ifeq ("$(WIN)", "64")
-    # TBB defaults to ia32
     MAKE_ARGS += arch=intel64
     ARCH_DIR=x64/
   else
+    MAKE_ARGS += arch=ia32
     ARCH_DIR=i386/
   endif
 

--- a/src/tbb/build/windows.gcc.inc
+++ b/src/tbb/build/windows.gcc.inc
@@ -49,7 +49,7 @@ PROXY.LIB =
 # Compiler-specific variables
 #------------------------------------------------------------------------------
 
-CPLUS = g++
+# CPLUS = g++
 COMPILE_ONLY = -c -MMD
 PREPROC_ONLY = -E -x c++
 INCLUDE_KEY = -I
@@ -101,7 +101,7 @@ CPLUS_FLAGS += -D_WIN32_WINNT=$(_WIN32_WINNT)
 # MinGW specific
 CPLUS_FLAGS += -DMINGW_HAS_SECURE_API=1 -D__MSVCRT_VERSION__=0x0700 -msse -mthreads
 
-CONLY = gcc
+# CONLY = gcc
 debugger = gdb
 C_FLAGS = $(CPLUS_FLAGS)
 


### PR DESCRIPTION
This PR overrides the `CONLY` and `CPLUS` variables (set and used by TBB for selecting the C and C++ compilers respectively) based on the values of `CC` and `CXX1X` set by R.

This should resolve compilation issues on Windows when `cygpath.exe` is not present.