### PR TITLE
fix compilation with gcc 7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RcppParallel
 Type: Package
 Title: Parallel Programming Tools for 'Rcpp'
-Version: 4.3.19
+Version: 4.3.20
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut"), email = "jj@rstudio.com"),
     person("Romain", "Francois", role = c("aut", "cph")),

--- a/inst/include/tbb/tbb_config.h
+++ b/inst/include/tbb/tbb_config.h
@@ -224,7 +224,7 @@
 
 // C++11 standard library features
 
-#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700)
+#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GCC_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__))
 #define __TBB_TR1_TYPE_PROPERTIES_IN_STD_PRESENT (__GXX_EXPERIMENTAL_CXX0X__ && __TBB_GCC_VERSION >= 40300 || _MSC_VER >= 1600)
 //TODO: Probably more accurate way is to analyze version of stdlibc++ via__GLIBCXX__ instead of __TBB_GCC_VERSION
 #define __TBB_ALLOCATOR_TRAITS_PRESENT           (__cplusplus >= 201103L && _LIBCPP_VERSION  || _MSC_VER >= 1700 ||                                             \

--- a/inst/include/tbb/tbb_config.h
+++ b/inst/include/tbb/tbb_config.h
@@ -224,7 +224,7 @@
 
 // C++11 standard library features
 
-#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GCC_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__))
+#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GCC_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
 #define __TBB_TR1_TYPE_PROPERTIES_IN_STD_PRESENT (__GXX_EXPERIMENTAL_CXX0X__ && __TBB_GCC_VERSION >= 40300 || _MSC_VER >= 1600)
 //TODO: Probably more accurate way is to analyze version of stdlibc++ via__GLIBCXX__ instead of __TBB_GCC_VERSION
 #define __TBB_ALLOCATOR_TRAITS_PRESENT           (__cplusplus >= 201103L && _LIBCPP_VERSION  || _MSC_VER >= 1700 ||                                             \

--- a/src/tbb/include/tbb/tbb_config.h
+++ b/src/tbb/include/tbb/tbb_config.h
@@ -224,7 +224,7 @@
 
 // C++11 standard library features
 
-#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700)
+#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GCC_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__))
 #define __TBB_TR1_TYPE_PROPERTIES_IN_STD_PRESENT (__GXX_EXPERIMENTAL_CXX0X__ && __TBB_GCC_VERSION >= 40300 || _MSC_VER >= 1600)
 //TODO: Probably more accurate way is to analyze version of stdlibc++ via__GLIBCXX__ instead of __TBB_GCC_VERSION
 #define __TBB_ALLOCATOR_TRAITS_PRESENT           (__cplusplus >= 201103L && _LIBCPP_VERSION  || _MSC_VER >= 1700 ||                                             \

--- a/src/tbb/include/tbb/tbb_config.h
+++ b/src/tbb/include/tbb/tbb_config.h
@@ -224,7 +224,7 @@
 
 // C++11 standard library features
 
-#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GCC_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__))
+#define __TBB_CPP11_TYPE_PROPERTIES_PRESENT      (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GCC_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
 #define __TBB_TR1_TYPE_PROPERTIES_IN_STD_PRESENT (__GXX_EXPERIMENTAL_CXX0X__ && __TBB_GCC_VERSION >= 40300 || _MSC_VER >= 1600)
 //TODO: Probably more accurate way is to analyze version of stdlibc++ via__GLIBCXX__ instead of __TBB_GCC_VERSION
 #define __TBB_ALLOCATOR_TRAITS_PRESENT           (__cplusplus >= 201103L && _LIBCPP_VERSION  || _MSC_VER >= 1700 ||                                             \


### PR DESCRIPTION
This PR fixes an issue reported by CRAN re: compilation of RcppParallel with gcc 7. The overarching issue is that `std::has_trivial_copy_constructor` is now removed, in favor of the (standardized) `std::is_trivially_copyable`.

From http://www.stats.ox.ac.uk/pub/bdr/ModernC++/R-devel-gcc7/RcppParallel.out:

```
* installing *source* package â€˜RcppParallelâ€™ ...
** package â€˜RcppParallelâ€™ successfully unpacked and MD5 sums checked
** libs
make[1]: Entering directory '/data/gannet/ripley/R/packages/install-C++/RcppParallel/src'
mkdir -p ../inst/lib/; \
cd tbb/src; \
if [ -n "" ]; then \
   make cpp0x=1 compiler=clang CXXFLAGS=-DTBB_NO_LEGACY=1 tbb_release tbbmalloc_release tbb_build_prefix=lib; \
elif [ -n "gcc" ]; then \
   make cpp0x=1 compiler=gcc CXXFLAGS=-DTBB_NO_LEGACY=1 tbb_release tbbmalloc_release tbb_build_prefix=lib; \
else \
   make cpp0x=1 CXXFLAGS=-DTBB_NO_LEGACY=1 tbb_release tbbmalloc_release tbb_build_prefix=lib; \
fi; \
cd ../..; \
cp tbb/build/lib_release/libtbb*.* ../inst/lib/
make[2]: Entering directory '/data/gannet/ripley/R/packages/install-C++/RcppParallel/src/tbb/src'
Created ../build/lib_release directory
make -C "../build/lib_release"  -r -f ../../build/Makefile.tbb cfg=release
make[3]: Entering directory '/data/gannet/ripley/R/packages/install-C++/RcppParallel/src/tbb/build/lib_release'
../../build/Makefile.tbb:31: CONFIG: cfg=release arch=intel64 compiler=gcc target=linux runtime=cc7.0.0_libc2.23_kernel4.6.4
g++ -o concurrent_hash_map.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_hash_map.cpp
g++ -o concurrent_queue.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_queue.cpp
g++ -o concurrent_vector.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_vector.cpp
g++ -o dynamic_link.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/dynamic_link.cpp
g++ -o itt_notify.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/itt_notify.cpp
g++ -o cache_aligned_allocator.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/cache_aligned_allocator.cpp
g++ -o pipeline.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64  -fPIC -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-non-virtual-dtor -DTBB_NO_LEGACY=1 -std=c++0x -D_TBB_CPP0X  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/pipeline.cpp
In file included from ../../src/tbb/pipeline.cpp:21:0:
../../include/tbb/pipeline.h:328:69: error: 'has_trivial_copy_constructor' is not a member of 'std'
 template<typename T> struct tbb_trivially_copyable { enum { value = std::has_trivial_copy_constructor<T>::value }; };
                                                                     ^~~
../../include/tbb/pipeline.h:328:104: error: expected primary-expression before '>' token
 template<typename T> struct tbb_trivially_copyable { enum { value = std::has_trivial_copy_constructor<T>::value }; };
                                                                                                        ^
../../include/tbb/pipeline.h:328:105: error: '::value' has not been declared
 template<typename T> struct tbb_trivially_copyable { enum { value = std::has_trivial_copy_constructor<T>::value }; };
                                                                                                         ^~
../../build/common_rules.inc:77: recipe for target 'pipeline.o' failed
make[3]: *** [pipeline.o] Error 1
make[3]: Leaving directory '/data/gannet/ripley/R/packages/install-C++/RcppParallel/src/tbb/build/lib_release'
Makefile:101: recipe for target 'tbb_release' failed
make[2]: *** [tbb_release] Error 2
make[2]: Leaving directory '/data/gannet/ripley/R/packages/install-C++/RcppParallel/src/tbb/src'
cp: cannot stat 'tbb/build/lib_release/libtbb*.*': No such file or directory
Makevars:73: recipe for target 'tbb' failed
make[1]: *** [tbb] Error 1
make[1]: Leaving directory '/data/gannet/ripley/R/packages/install-C++/RcppParallel/src'
ERROR: compilation failed for package â€˜RcppParallelâ€™
* removing â€˜/data/gannet/ripley/R/packages/install-C++/Libs/RcppParallel-lib/RcppParallelâ€™
Time 0:10.26, 9.06 + 0.72
```

This patch changes this line of code to be identical to what is currently used in the development version of TBB, and so I believe it should be safe -- but let me test on an VM first to be sure.