### PR TITLE
add 'RcppParallel.package.skeleton()', for generating RcppParallel-using R package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,4 @@ Collate:
    'build.R'
    'hooks.R'
    'options.R'
+   'skeleton.R'

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -1,0 +1,97 @@
+RcppParallel.package.skeleton <- function(name = "anRpackage",
+                                          example_code = TRUE,
+                                          ...)
+{
+   # call Rcpp.package.skeleton() -- provide 'list' explicitly
+   # and clean up after
+   env <- new.env(parent = emptyenv())
+   env$dummy <- NULL
+   Rcpp::Rcpp.package.skeleton(
+      name = name,
+      attributes = FALSE,
+      module = FALSE,
+      example_code = FALSE,
+      environment = env,
+      list = "dummy",
+      ...
+   )
+   
+   # move to generated package directory
+   owd <- setwd(name)
+   on.exit(setwd(owd), add = TRUE)
+   
+   # remove dummy stuff
+   unlink("data/dummy.Rda")
+   unlink("man/dummy.Rd")
+   
+   message("\nAdding RcppParallel settings")
+   
+   # update DESCRIPTION file
+   desc <- read.dcf("DESCRIPTION", all = TRUE, keep.white = TRUE)
+   version <- sprintf("RcppParallel (>= %s)", utils::packageVersion("RcppParallel"))
+   
+   desc$Imports <- paste0(desc$Imports, ", ", version)
+   message(" >> added Imports: ", desc$Imports)
+   
+   desc$LinkingTo <- paste0(desc$LinkingTo, ", RcppParallel")
+   message(" >> added LinkingTo: ", desc$LinkingTo)
+   
+   desc$SystemRequirements <- "GNU make"
+   message(" >> added SystemRequirements: GNU make")
+   
+   write.dcf(desc, file = "DESCRIPTION", keep.white = TRUE)
+   
+   # update NAMESPACE file
+   message(" >> added importFrom(RcppParallel,RcppParallelLibs) directive to NAMESPACE")
+   cat("importFrom(RcppParallel,RcppParallelLibs)",
+      file = "NAMESPACE",
+      sep = "\n",
+      append = TRUE)
+   
+   # write Makevars files
+   dir.create("src", showWarnings = FALSE)
+   
+   # src/Makevars
+   message(" >> added src/Makevars")
+   cat(
+      c(
+         'CXX_STD = CXX11',
+         'PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")'
+      ),
+      file = "src/Makevars",
+      sep = "\n"
+   )
+   
+   # src/Makevars.win
+   message(" >> added src/Makevars.win")
+   cat(
+      c(
+         'CXX_STD = CXX11',
+         'PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1',
+         'PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::RcppParallelLibs()")'
+      ),
+      file = "src/Makevars.win",
+      sep = "\n"
+   )
+   
+   # write an example script using RcppParallel
+   if (example_code) {
+      
+      message(" >> added example file src/vector-sum.cpp")
+      file.copy(
+         system.file("skeleton/vector-sum.cpp", package = "RcppParallel"),
+         "src/vector-sum.cpp"
+      )
+      
+      message(" >> added example documentation man/vector-sum.Rd")
+      file.copy(
+         system.file("skeleton/vector-sum.Rd", package = "RcppParallel"),
+         "man/vector-sum.Rd"
+      )
+      
+      message(" >> compiled Rcpp attributes")
+      Rcpp::compileAttributes()
+   }
+   
+   TRUE
+}

--- a/inst/skeleton/vector-sum.Rd
+++ b/inst/skeleton/vector-sum.Rd
@@ -1,0 +1,20 @@
+\name{parallelVectorSum}
+\alias{parallelVectorSum}
+\docType{package}
+\title{
+Simple function using RcppParallel
+}
+\description{
+Simple function using RcppParallel
+}
+\usage{
+parallelVectorSum(x)
+}
+\arguments{
+\item{x}{A numeric vector.}
+}
+\examples{
+\dontrun{
+parallelVectorSum(1:20)
+}
+}

--- a/inst/skeleton/vector-sum.cpp
+++ b/inst/skeleton/vector-sum.cpp
@@ -1,0 +1,42 @@
+// [[Rcpp::depends(RcppParallel)]]
+#include <Rcpp.h>
+#include <RcppParallel.h>
+
+using namespace Rcpp;
+using namespace RcppParallel;
+
+struct Sum : public Worker
+{   
+   // source vector
+   const RVector<double> input;
+   
+   // accumulated value
+   double value;
+   
+   // constructors
+   Sum(const NumericVector input) : input(input), value(0) {}
+   Sum(const Sum& sum, Split) : input(sum.input), value(0) {}
+   
+   // accumulate just the element of the range I've been asked to
+   void operator()(std::size_t begin, std::size_t end) {
+      value += std::accumulate(input.begin() + begin, input.begin() + end, 0.0);
+   }
+   
+   // join my value with that of another Sum
+   void join(const Sum& rhs) { 
+      value += rhs.value; 
+   }
+};
+
+// [[Rcpp::export]]
+double parallelVectorSum(NumericVector x) {
+   
+   // declare the SumBody instance 
+   Sum sum(x);
+   
+   // call parallel_reduce to start the work
+   parallelReduce(0, x.length(), sum);
+   
+   // return the computed sum
+   return sum.value;
+}

--- a/man/RcppParallel.package.skeleton.Rd
+++ b/man/RcppParallel.package.skeleton.Rd
@@ -1,0 +1,65 @@
+\name{RcppParallel.package.skeleton}
+\alias{RcppParallel.package.skeleton}
+\title{
+Create a skeleton for a new package depending on RcppParallel
+}
+\description{
+	\code{RcppParallel.package.skeleton} automates the creation of 
+	a new source package that intends to use features of RcppParallel. 
+	
+	It is based on the \link[utils]{package.skeleton} function
+	which it executes first.
+}
+\usage{
+RcppParallel.package.skeleton(
+    name = "anRpackage",
+    example_code = TRUE,
+    ...
+)
+}
+\arguments{
+	\item{name}{The name of your R package.}
+	\item{example_code}{If \code{TRUE}, example C++ code using RcppParallel is added to the package.}
+	\item{...}{Optional arguments passed to \link[Rcpp]{Rcpp.package.skeleton}.}
+}
+\details{
+	In addition to \link[Rcpp]{Rcpp.package.skeleton} :
+	
+	The \samp{DESCRIPTION} file gains an Imports line requesting that 
+	the package depends on RcppParallel and a LinkingTo line so that the package
+	finds RcppParallel header files.
+	
+	The \samp{NAMESPACE} gains a \code{useDynLib} directive as well
+	as an \code{importFrom(RcppParallel, evalCpp} to ensure instantiation of RcppParallel.
+	
+	The \samp{src} directory is created if it does not exists and 
+	a \samp{Makevars} file is added setting the environment variables
+	\samp{PKG_LIBS} to accomodate the necessary flags to link with the RcppParallel library. 
+	
+	If the \code{example_code} argument is set to \code{TRUE}, 
+	example files \samp{vector-sum.cpp} is created in the \samp{src} directory.
+	\code{Rcpp::compileAttributes()} is then called to generate \code{src/RcppExports.cpp} and
+	\code{R/RcppExports.R}. These files are given as an example and should 
+	eventually by removed from the generated package.
+}
+\value{
+Nothing, used for its side effects
+}
+\seealso{
+\link[utils]{package.skeleton}
+}
+\references{
+Read the \emph{Writing R Extensions} manual for more details.
+
+Once you have created a \emph{source} package you need to install it:
+see the \emph{R Installation and Administration} manual,
+\code{\link{INSTALL}} and \code{\link{install.packages}}.
+}
+\examples{
+\dontrun{
+# simple package
+RcppParallel.package.skeleton( "foobar" )
+}
+}
+\keyword{ programming }
+


### PR DESCRIPTION
This PR adds a skeleton function for generating packages ready to use RcppParallel. We call into `Rcpp.package.skeleton()` and then add the extra bits necessary for using RcppParallel.

cc: @jjallaire @eddelbuettel 