### PR TITLE
provide metadata for registration of project template with RStudio

### DIFF
--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -23,6 +23,7 @@ RcppParallel.package.skeleton <- function(name = "anRpackage",
    # remove dummy stuff
    unlink("data/dummy.Rda")
    unlink("man/dummy.Rd")
+   unlink("Read-and-delete-me")
    
    message("\nAdding RcppParallel settings")
    

--- a/inst/rstudio/templates/project/RcppParallel.package.skeleton.dcf
+++ b/inst/rstudio/templates/project/RcppParallel.package.skeleton.dcf
@@ -2,7 +2,7 @@ Binding: RcppParallel.package.skeleton
 Title: R Package using RcppParallel
 Subtitle: Create a new R Package using RcppParallel
 Caption: Create R Package using RcppParallel
-OpenFiles: Read-and-delete-me, src/vector-sum.cpp
+OpenFiles: src/vector-sum.cpp
 
 Parameter: example_code
 Widget: CheckboxInput

--- a/inst/rstudio/templates/project/RcppParallel.package.skeleton.dcf
+++ b/inst/rstudio/templates/project/RcppParallel.package.skeleton.dcf
@@ -6,5 +6,5 @@ OpenFiles: Read-and-delete-me, src/vector-sum.cpp
 
 Parameter: example_code
 Widget: CheckboxInput
-Label: Include an example C++ file using RcppParallel?
+Label: Include an example C++ file using RcppParallel
 Default: On

--- a/inst/rstudio/templates/project/RcppParallel.package.skeleton.dcf
+++ b/inst/rstudio/templates/project/RcppParallel.package.skeleton.dcf
@@ -1,0 +1,10 @@
+Binding: RcppParallel.package.skeleton
+Title: R Package using RcppParallel
+Subtitle: Create a new R Package using RcppParallel
+Caption: Create R Package using RcppParallel
+OpenFiles: Read-and-delete-me, src/vector-sum.cpp
+
+Parameter: example_code
+Widget: CheckboxInput
+Label: Include an example C++ file using RcppParallel?
+Default: On

--- a/inst/skeleton/vector-sum.cpp
+++ b/inst/skeleton/vector-sum.cpp
@@ -1,3 +1,16 @@
+/**
+ *
+ * This file contains example code showcasing how RcppParallel
+ * can be used. In this file, we define and export a function called
+ * 'parallelVectorSum()', which computes the sum of a numeric vector
+ * in parallel.
+ *
+ * Please see https://rcppcore.github.io/RcppParallel/ for more
+ * details on how to use RcppParallel in an R package, and the
+ * Rcpp gallery at http://gallery.rcpp.org/ for more examples.
+ *
+ */
+
 // [[Rcpp::depends(RcppParallel)]]
 #include <Rcpp.h>
 #include <RcppParallel.h>


### PR DESCRIPTION
This PR provides the registration metadata necessary to use `RcppParallel.package.skeleton()` within the `New Project...` wizard with development versions of RStudio.

![screen shot 2017-01-09 at 11 36 16 am](https://cloud.githubusercontent.com/assets/1976582/21780298/da7a3a02-d65f-11e6-9715-1bcde2aa4bcb.png)
