### PR TITLE
Add --vanilla to Rscript calls

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -4,7 +4,7 @@
 # inlineCxxPlugin (defined below) and to packages via a line in Makevars[.win]
 # like this:
 #
-#  PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
+#  PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla -e "RcppParallel::CxxFlags()")
 #
 CxxFlags <- function() {
    cat(tbbCxxFlags())
@@ -15,7 +15,7 @@ CxxFlags <- function() {
 # to sourceCpp via the inlineCxxPlugin (defined below) and to packages 
 # via a line in Makevars[.win] like this:
 #
-#   PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::LdFlags()")
+#   PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla -e "RcppParallel::LdFlags()")
 #
 LdFlags <- function() {
    cat(tbbLdFlags())

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -57,7 +57,7 @@ RcppParallel.package.skeleton <- function(name = "anRpackage",
    cat(
       c(
          'CXX_STD = CXX11',
-         'PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")'
+         'PKG_LIBS += $(shell ${R_HOME}/bin/Rscript --vanilla -e "RcppParallel::RcppParallelLibs()")'
       ),
       file = "src/Makevars",
       sep = "\n"
@@ -69,7 +69,7 @@ RcppParallel.package.skeleton <- function(name = "anRpackage",
       c(
          'CXX_STD = CXX11',
          'PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1',
-         'PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::RcppParallelLibs()")'
+         'PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla -e "RcppParallel::RcppParallelLibs()")'
       ),
       file = "src/Makevars.win",
       sep = "\n"

--- a/man/RcppParallelFlags.Rd
+++ b/man/RcppParallelFlags.Rd
@@ -17,7 +17,7 @@ RcppParallelLibs()
 \details{
 These functions are typically called from \code{Makevars} as follows:
 
-\code{PKG_LIBS += $(shell "${R_HOME}/bin/Rscript/" -e "RcppParallel::LdFlags()")}
+\code{PKG_LIBS += $(shell "${R_HOME}/bin/Rscript" --vanilla -e "RcppParallel::LdFlags()")}
 
 }
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -61,7 +61,7 @@ endif
 
 # For Solaris detect if this is 32-bit R on x86 and if so forward that to TBB
 ifeq ($(USE_TBB),  SunOS)
-   R_32BIT = $(shell ${R_HOME}/bin/Rscript -e 'cat(.Machine$$sizeof.pointer == 4)')
+   R_32BIT = $(shell ${R_HOME}/bin/Rscript --vanilla -e 'cat(.Machine$$sizeof.pointer == 4)')
    ifeq ($(R_32BIT), TRUE)
       MAKE_ARGS += arch=ia32
    endif


### PR DESCRIPTION
There seems to be a reasonably common breakage when not using `--vanilla` with `Rscript` when capturing output. 

This pull request adds the option to the documentation and skeleton.

### References
benjjneb/dada2#418

