### PR TITLE
fixups for Rtools 3.5

### DIFF
--- a/src/tbb/build/version_info_windows.js
+++ b/src/tbb/build/version_info_windows.js
@@ -93,3 +93,4 @@ WScript.echo( "#define __TBB_DATETIME \"" + date.toUTCString() + "\"" );
 WScript.echo( "#define __TBB_VERSION_YMD " + date.getUTCFullYear() + ", " + 
               (date.getUTCMonth() > 8 ? (date.getUTCMonth()+1):("0"+(date.getUTCMonth()+1))) + 
               (date.getUTCDate() > 9 ? date.getUTCDate():("0"+date.getUTCDate())) );
+WScript.echo( "" )

--- a/src/tbb/build/windows.inc
+++ b/src/tbb/build/windows.inc
@@ -120,7 +120,7 @@ ifneq ($(filter vc8 vc9,$(runtime)),)
 RML.MANIFEST = tbbmanifest.exe.manifest
 endif
 
-MAKE_VERSIONS = $(CMD) cscript /nologo /E:jscript $(subst \,/,$(tbb_root))/build/version_info_windows.js $(compiler) $(arch) $(subst \,/,"$(VERSION_FLAGS)") > version_string.ver
+MAKE_VERSIONS = $(CMD) "cscript /nologo /E:jscript $(subst \,/,$(tbb_root))/build/version_info_windows.js $(CONLY) $(arch) $(subst \,/,$(VERSION_FLAGS))" > version_string.ver
 MAKE_TBBVARS  = $(CMD) "$(subst /,\,$(tbb_root))\build\generate_tbbvars.bat"
 
 TEST_LAUNCHER = $(subst /,\,$(tbb_root))\build\test_launcher.bat $(largs)


### PR DESCRIPTION
- Tweak command quoting when attempting to invoke `cscript`.
- Use `$(CONLY)` rather than `$(compiler)` as this provides the full path to the C compiler used. (The previous method assumed that `gcc` would be on the PATH, which appears not always be true)

I tested and this appears to be backwards-compatible with older versions of Rtools so I think this should be safe to take.