### PR TITLE
Fix finding of CXX prefix

### DIFF
--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -6,7 +6,7 @@ candidates <- c("CXX11", "CXX1X", "CXX")
 for (candidate in candidates) {
    config <- read_r_config(candidate, envir = NULL)
    value <- config[[candidate]]
-   if (!is.null(value)) {
+   if (!is.null(value) && !(startsWith(value, "ERROR:"))) {
       cxx <- candidate
       break
    }
@@ -26,7 +26,7 @@ if (broken)
 # configuration of R
 switch(
    cxx,
-   
+
    CXX11 = define(
       CC            = "$(CC)",
       CXX11         = "$(CXX11)",
@@ -34,7 +34,7 @@ switch(
       CXX11STD      = "$(CXX11STD)",
       CXX11PICFLAGS = "$(CXX11PICFLAGS)"
    ),
-   
+
    CXX1X = define(
       CC            = "$(CC)",
       CXX11         = "$(CXX1X)",
@@ -42,7 +42,7 @@ switch(
       CXX11STD      = "$(CXX1XSTD)",
       CXX11PICFLAGS = "$(CXX1XPICFLAGS)"
    ),
-   
+
    CXX = define(
       CC            = "$(CC)",
       CXX11         = "$(CXX)",
@@ -50,14 +50,14 @@ switch(
       CXX11STD      = "-std=c++0x",
       CXX11PICFLAGS = "-fPIC"
    ),
-   
+
    stop("Failed to infer C / C++ compilation flags")
 )
 
 # define special flags for Windows
 db <- configure_database()
 if (Sys.info()[["sysname"]] == "Windows") {
-   
+
    cygpath <- nzchar(Sys.which("cygpath"))
    fmt <- if (cygpath) "$(shell cygpath -m \"%s\")" else "%s"
    define(


### PR DESCRIPTION
When installing `RcppParallel` in its newest version on our machines (Debian 9.5 stretch, R version 3.3.3), we (@bockthom and myself) experience compilation errors with this package (see below). It worked before with version 3.4.20. 

During debugging, we tracked it down to the finding of the `CXX` prefix in the configure script:
https://github.com/RcppCore/RcppParallel/blob/efc284f6c7f81603021967b8d6c9c12ac4f3695f/tools/config/configure.R#L2-L13

After these lines of code, `cxx` was set to `CXX11`, while `value` indicated an error:
```
> cxx
[1] "CXX11"
> value
[1] "ERROR: no information for variable 'CXX11'"
attr(,"status")
[1] 1
```

Hopefully, we fixed the problem (hopefully!) in the only commit of this PR (8bbf1d9ab648f002a3c27f6735843273abdff457) by checking whether `value` indicates an error (i.e, starts with `"ERROR:"`).

Keep up the good work and do not hesitate to argue about the change. :wink: 

### Exemplary compilation error

<details>
<summary>Output when running <code lang="R">install.packages("RcppParallel", repos="http://cloud.r-project.org")</code></summary>

<pre>
R version 3.3.3 (2017-03-06) -- "Another Canoe"
Copyright (C) 2017 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> install.packages("RcppParallel", repos="http://cloud.r-project.org")
Installing package into ‘/tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3’
(as ‘lib’ is unspecified)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1235k  100 1235k    0     0  3381k      0 --:--:-- --:--:-- --:--:-- 3384k
* installing *source* package ‘RcppParallel’ ...
** package ‘RcppParallel’ successfully unpacked and MD5 sums checked
* preparing to configure package 'RcppParallel' ...
** executing 'R CMD config'
** executing 'R CMD config'
** configured file: 'src/Makevars.in' => 'src/Makevars'
* finished configure for package 'RcppParallel'
Warning messages:
1: running command ''/usr/lib/R/bin/R' CMD config CXX11' had status 1 
2: running command ''/usr/lib/R/bin/R' CMD config CXX11FLAGS' had status 1 
** libs
mkdir -p ../inst/lib/; \
cd tbb/src; \
if [ -n "" ]; then \
   CONLY="gcc -std=gnu99" CPLUS="" CXXFLAGS="ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1" PIC_KEY="" WARNING_SUPPRESS="" make -e stdver=c++0x compiler=clang tbb_release tbbmalloc_release tbb_build_prefix=lib; \
elif [ -n "gcc -std=gnu99" ]; then \
   CONLY="gcc -std=gnu99" CPLUS="" CXXFLAGS="ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1" PIC_KEY="" WARNING_SUPPRESS="" make -e stdver=c++0x compiler=gcc tbb_release tbbmalloc_release tbb_build_prefix=lib; \
else \
   CONLY="gcc -std=gnu99" CPLUS="" CXXFLAGS="ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1" PIC_KEY="" WARNING_SUPPRESS="" make -e stdver=c++0x tbb_release tbbmalloc_release tbb_build_prefix=lib; \
fi; \
cd ../..; \
cp tbb/build/lib_release/libtbb*.* ../inst/lib/
make[1]: Entering directory '/tmp/Rtmp9GQ3aK/R.INSTALL373f7cc0be5c/RcppParallel/src/tbb/src'
Created ../build/lib_release directory
make -e -C "../build/lib_release"  -r -f ../../build/Makefile.tbb cfg=release
make[2]: Entering directory '/tmp/Rtmp9GQ3aK/R.INSTALL373f7cc0be5c/RcppParallel/src/tbb/build/lib_release'
../../build/Makefile.tbb:32: CONFIG: cfg=release arch=intel64 compiler=gcc target=linux runtime=cc6.3.0_libc2.24_kernel4.9.0
o concurrent_hash_map.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_hash_map.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'concurrent_hash_map.o' failed
make[2]: [concurrent_hash_map.o] Error 127 (ignored)
o concurrent_queue.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_queue.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'concurrent_queue.o' failed
make[2]: [concurrent_queue.o] Error 127 (ignored)
o concurrent_vector.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_vector.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'concurrent_vector.o' failed
make[2]: [concurrent_vector.o] Error 127 (ignored)
o dynamic_link.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/dynamic_link.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'dynamic_link.o' failed
make[2]: [dynamic_link.o] Error 127 (ignored)
o itt_notify.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/itt_notify.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'itt_notify.o' failed
make[2]: [itt_notify.o] Error 127 (ignored)
o cache_aligned_allocator.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/cache_aligned_allocator.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'cache_aligned_allocator.o' failed
make[2]: [cache_aligned_allocator.o] Error 127 (ignored)
o pipeline.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/pipeline.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'pipeline.o' failed
make[2]: [pipeline.o] Error 127 (ignored)
o queuing_mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/queuing_mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'queuing_mutex.o' failed
make[2]: [queuing_mutex.o] Error 127 (ignored)
o queuing_rw_mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/queuing_rw_mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'queuing_rw_mutex.o' failed
make[2]: [queuing_rw_mutex.o] Error 127 (ignored)
o reader_writer_lock.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/reader_writer_lock.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'reader_writer_lock.o' failed
make[2]: [reader_writer_lock.o] Error 127 (ignored)
o spin_rw_mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/spin_rw_mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'spin_rw_mutex.o' failed
make[2]: [spin_rw_mutex.o] Error 127 (ignored)
o x86_rtm_rw_mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/x86_rtm_rw_mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'x86_rtm_rw_mutex.o' failed
make[2]: [x86_rtm_rw_mutex.o] Error 127 (ignored)
o spin_mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/spin_mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'spin_mutex.o' failed
make[2]: [spin_mutex.o] Error 127 (ignored)
o critical_section.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/critical_section.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'critical_section.o' failed
make[2]: [critical_section.o] Error 127 (ignored)
o mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'mutex.o' failed
make[2]: [mutex.o] Error 127 (ignored)
o recursive_mutex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/recursive_mutex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'recursive_mutex.o' failed
make[2]: [recursive_mutex.o] Error 127 (ignored)
o condition_variable.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/condition_variable.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'condition_variable.o' failed
make[2]: [condition_variable.o] Error 127 (ignored)
o tbb_thread.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/tbb_thread.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'tbb_thread.o' failed
make[2]: [tbb_thread.o] Error 127 (ignored)
o concurrent_monitor.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/concurrent_monitor.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'concurrent_monitor.o' failed
make[2]: [concurrent_monitor.o] Error 127 (ignored)
o semaphore.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/semaphore.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'semaphore.o' failed
make[2]: [semaphore.o] Error 127 (ignored)
o private_server.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/private_server.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'private_server.o' failed
make[2]: [private_server.o] Error 127 (ignored)
o rml_tbb.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/rml/client/rml_tbb.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'rml_tbb.o' failed
make[2]: [rml_tbb.o] Error 127 (ignored)
sh ../../build/version_info_linux.sh  -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x -I../../src -I../../src/rml/include -I../../include -I. >version_string.ver
o tbb_misc.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include -I. ../../src/tbb/tbb_misc.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'tbb_misc.o' failed
make[2]: [tbb_misc.o] Error 127 (ignored)
o tbb_misc_ex.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/tbb_misc_ex.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'tbb_misc_ex.o' failed
make[2]: [tbb_misc_ex.o] Error 127 (ignored)
o task.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/task.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'task.o' failed
make[2]: [task.o] Error 127 (ignored)
o task_group_context.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/task_group_context.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'task_group_context.o' failed
make[2]: [task_group_context.o] Error 127 (ignored)
o governor.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/governor.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'governor.o' failed
make[2]: [governor.o] Error 127 (ignored)
o market.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/market.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'market.o' failed
make[2]: [market.o] Error 127 (ignored)
o arena.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/arena.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'arena.o' failed
make[2]: [arena.o] Error 127 (ignored)
o scheduler.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/scheduler.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'scheduler.o' failed
make[2]: [scheduler.o] Error 127 (ignored)
o observer_proxy.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/observer_proxy.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'observer_proxy.o' failed
make[2]: [observer_proxy.o] Error 127 (ignored)
o tbb_statistics.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/tbb_statistics.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'tbb_statistics.o' failed
make[2]: [tbb_statistics.o] Error 127 (ignored)
o tbb_main.o -c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -std=c++0x  -I../../src -I../../src/rml/include -I../../include ../../src/tbb/tbb_main.cpp
make[2]: o: Command not found
../../build/common_rules.inc:79: recipe for target 'tbb_main.o' failed
make[2]: [tbb_main.o] Error 127 (ignored)
sh ../../build/generate_tbbvars.sh
echo "INPUT (libtbb.so.2)" > libtbb.so
E -x c++ ../../src/tbb/lin64-tbb-export.def -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   -flifetime-dse=1 -D__TBB_BUILD=1 -Wall  ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -I../../src -I../../src/rml/include -I../../include > tbb.def
/bin/sh: 1: E: not found
../../build/Makefile.tbb:96: recipe for target 'tbb.def' failed
make[2]: [tbb.def] Error 127 (ignored)
o libtbb.so.2 concurrent_hash_map.o concurrent_queue.o concurrent_vector.o dynamic_link.o itt_notify.o cache_aligned_allocator.o pipeline.o queuing_mutex.o queuing_rw_mutex.o reader_writer_lock.o spin_rw_mutex.o x86_rtm_rw_mutex.o spin_mutex.o critical_section.o mutex.o recursive_mutex.o condition_variable.o tbb_thread.o concurrent_monitor.o semaphore.o private_server.o rml_tbb.o tbb_misc.o tbb_misc_ex.o task.o task_group_context.o governor.o market.o arena.o scheduler.o observer_proxy.o tbb_statistics.o tbb_main.o    -ldl -lpthread -lrt -shared -Wl,-soname=libtbb.so.2 -m64  -Wl,--version-script,tbb.def
make[2]: o: Command not found
../../build/Makefile.tbb:107: recipe for target 'libtbb.so.2' failed
make[2]: [libtbb.so.2] Error 127 (ignored)
make[2]: Leaving directory '/tmp/Rtmp9GQ3aK/R.INSTALL373f7cc0be5c/RcppParallel/src/tbb/build/lib_release'
make -e -C "../build/lib_release"  -r -f ../../build/Makefile.tbbmalloc cfg=release malloc
make[2]: Entering directory '/tmp/Rtmp9GQ3aK/R.INSTALL373f7cc0be5c/RcppParallel/src/tbb/build/lib_release'
c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1    -flifetime-dse=1 -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/tbbmalloc/backend.cpp
make[2]: c: Command not found
../../build/Makefile.tbbmalloc:69: recipe for target 'backend.o' failed
make[2]: [backend.o] Error 127 (ignored)
c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1    -flifetime-dse=1 -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/tbbmalloc/large_objects.cpp
make[2]: c: Command not found
../../build/Makefile.tbbmalloc:69: recipe for target 'large_objects.o' failed
make[2]: [large_objects.o] Error 127 (ignored)
c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1    -flifetime-dse=1 -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/tbbmalloc/backref.cpp
make[2]: c: Command not found
../../build/Makefile.tbbmalloc:69: recipe for target 'backref.o' failed
make[2]: [backref.o] Error 127 (ignored)
c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1    -flifetime-dse=1 -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/tbbmalloc/tbbmalloc.cpp
make[2]: c: Command not found
../../build/Makefile.tbbmalloc:69: recipe for target 'tbbmalloc.o' failed
make[2]: [tbbmalloc.o] Error 127 (ignored)
c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1    -flifetime-dse=1 -o itt_notify_malloc.o -I../../src -I../../src/rml/include -I../../include ../../src/tbb/itt_notify.cpp
make[2]: c: Command not found
../../build/Makefile.tbbmalloc:72: recipe for target 'itt_notify_malloc.o' failed
make[2]: [itt_notify_malloc.o] Error 127 (ignored)
c -MMD -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1    -flifetime-dse=1 -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc -I. ../../src/tbbmalloc/frontend.cpp
make[2]: c: Command not found
../../build/Makefile.tbbmalloc:63: recipe for target 'frontend.o' failed
make[2]: [frontend.o] Error 127 (ignored)
echo "INPUT (libtbbmalloc.so.2)" > libtbbmalloc.so
E -x c++ ../../src/tbbmalloc/lin64-tbbmalloc-export.def -DDO_ITT_NOTIFY -g -O2 -DUSE_PTHREAD -m64 -mrtm   ERROR: no information for variable 'CXX11FLAGS' -DTBB_NO_LEGACY=1 -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include > tbbmalloc.def
/bin/sh: 1: E: not found
../../build/Makefile.tbbmalloc:79: recipe for target 'tbbmalloc.def' failed
make[2]: [tbbmalloc.def] Error 127 (ignored)
gcc -std=gnu99 -o libtbbmalloc.so.2 backend.o large_objects.o backref.o  tbbmalloc.o  itt_notify_malloc.o frontend.o  -ldl -lpthread -lrt -shared -Wl,-soname=libtbbmalloc.so.2 -m64  -Wl,--version-script,tbbmalloc.def
gcc: error: backend.o: No such file or directory
gcc: error: large_objects.o: No such file or directory
gcc: error: backref.o: No such file or directory
gcc: error: tbbmalloc.o: No such file or directory
gcc: error: itt_notify_malloc.o: No such file or directory
gcc: error: frontend.o: No such file or directory
../../build/Makefile.tbbmalloc:89: recipe for target 'libtbbmalloc.so.2' failed
make[2]: *** [libtbbmalloc.so.2] Error 1
make[2]: Leaving directory '/tmp/Rtmp9GQ3aK/R.INSTALL373f7cc0be5c/RcppParallel/src/tbb/build/lib_release'
Makefile:129: recipe for target 'tbbmalloc_release' failed
make[1]: *** [tbbmalloc_release] Error 2
make[1]: Leaving directory '/tmp/Rtmp9GQ3aK/R.INSTALL373f7cc0be5c/RcppParallel/src/tbb/src'
g++ -I/usr/share/R/include -DNDEBUG  -I../inst/include/ -DRCPP_PARALLEL_USE_TBB=1  -I"/tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/BH/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-3.3.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c init.cpp -o init.o
g++ -I/usr/share/R/include -DNDEBUG  -I../inst/include/ -DRCPP_PARALLEL_USE_TBB=1  -I"/tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/BH/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-3.3.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c options.cpp -o options.o
g++ -shared -L/usr/lib/R/lib -Wl,-z,relro -o RcppParallel.so init.o options.o -L/usr/lib/R/lib -lR
installing to /tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/RcppParallel/libs
** R
** inst
** preparing package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded
Warning in fun(libname, pkgname) : TBB library  not found.
Warning in fun(libname, pkgname) : TBB malloc library  not found.
Error : .onLoad failed in loadNamespace() for 'RcppParallel', details:
  call: dyn.load(file, DLLpath = DLLpath, ...)
  error: unable to load shared object '/tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/RcppParallel/libs/RcppParallel.so':
  /tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/RcppParallel/libs/RcppParallel.so: undefined symbol: _ZN3tbb19task_scheduler_init9terminateEv
Error: loading failed
Execution halted
ERROR: loading failed
* removing ‘/tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/RcppParallel’
* restoring previous ‘/tmp/test/foo/packrat/lib/x86_64-pc-linux-gnu/3.3.3/RcppParallel’

The downloaded source packages are in
	‘/tmp/RtmpG9Gpa1/downloaded_packages’
Warning message:
In install.packages("RcppParallel", repos = "http://cloud.r-project.org") :
  installation of package ‘RcppParallel’ had non-zero exit status
>
</pre>

</details>


### CC

@bockthom