### PR TITLE
Fix a `row_iterator` constructor

### DIFF
--- a/inst/include/RcppParallel/RMatrix.h
+++ b/inst/include/RcppParallel/RMatrix.h
@@ -23,7 +23,7 @@ public:
          {
          }
          
-         inline row_iterator(std::size_t start, std::size_t parentNrow, std::size_t index)
+         inline row_iterator(V* start, std::size_t parentNrow, std::size_t index)
             : start_(start), parentNrow_(parentNrow), index_(index)
          {      
          }


### PR DESCRIPTION
The type of the first argument of this constructor should be `V*` instead of `std::size_t`
Fixes #86 