### PR TITLE
pass along CPPFLAGS during TBB compilation

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -35,8 +35,8 @@ else
 
   MAKE += -e -s
   MAKE_CMD =                                  \
-    CONLY="@CC@"                              \
-    CPLUS="@CXX11@"                           \
+    CONLY="@CC@ @CPPFLAGS@"                   \
+    CPLUS="@CXX11@ @CPPFLAGS@"                \
     CXXFLAGS="@CXX11FLAGS@ -DTBB_NO_LEGACY=1" \
     PIC_KEY="@CXX11PICFLAGS@"                 \
     WARNING_SUPPRESS=""                       \

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -28,6 +28,7 @@ switch(
    
    CXX11 = define(
       CC            = "$(CC)",
+      CPPFLAGS      = "$(CPPFLAGS)",
       CXX11         = "$(CXX11)",
       CXX11FLAGS    = cxxflags,
       CXX11STD      = "$(CXX11STD)",
@@ -36,6 +37,7 @@ switch(
    
    CXX1X = define(
       CC            = "$(CC)",
+      CPPFLAGS      = "$(CPPFLAGS)",
       CXX11         = "$(CXX1X)",
       CXX11FLAGS    = cxxflags,
       CXX11STD      = "$(CXX1XSTD)",
@@ -44,6 +46,7 @@ switch(
    
    CXX = define(
       CC            = "$(CC)",
+      CPPFLAGS      = "$(CPPFLAGS)",
       CXX11         = "$(CXX)",
       CXX11FLAGS    = cxxflags,
       CXX11STD      = "-std=c++0x",


### PR DESCRIPTION
Necessary on macOS Catalina (which no longer has `/usr/include`).