### PR TITLE
Set working directory for config.R correctly even if setwd is set outside

### DIFF
--- a/tools/config.R
+++ b/tools/config.R
@@ -574,6 +574,15 @@ if (!interactive()) {
     args <- commandArgs(TRUE)
     type <- args[[1]]
 
+    # preserve working directory
+    owd <- getwd()
+    on.exit(setwd(owd), add = TRUE)
+
+    # switch working directory to the calling scripts's directory as set
+    # by the shell, in case the R working directory was set to something else
+    basedir <- Sys.getenv("PWD", unset = ".")
+    setwd(basedir)
+
     # report start of execution
     package <- Sys.getenv("R_PACKAGE_NAME", unset = "<unknown>")
     fmt <- "** preparing to %s package '%s' ..."


### PR DESCRIPTION
`setwd` can be set in a `~/.Rprofile` or `Rprofile.site`, to provide a default path when R opens. This however confuses the config script, as the R working path might then be different from the system path from where the script is called.

This patch sets the current R code's working directory to the same as it was previously assumed, the calling scripts (`configure` or `cleanup`) folders, through the `PWD` shell env var. After this the relative paths for the tools folder becomes correct.

Tested on Linux. Suggestions for improvements are very much welcome.

Connects to and fixes #119 