### PR TITLE
Support Intel oneAPI TBB / oneTBB

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For additional documentation on using RcppParallel see the package website at ht
 
 ### Intel TBB
 
-`RcppParallel` now supports the new interface of Intel TBB and allows using external library (e.g., with [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html)), using `TBB_LIB` and `TBB_INC` environment variables. The updated TBB functionality are summarized [here](https://software.intel.com/content/www/us/en/develop/articles/tbb-revamp.html) and the release notes and backward compatibility are reported [here](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html).
+`RcppParallel` now supports the new interface of Intel TBB and allows using external library (e.g., with [oneTBB](https://github.com/oneapi-src/oneTBB), [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html), or the system TBB library), using `TBB_LIB` and `TBB_INC` environment variables. The updated TBB functionality are summarized [here](https://software.intel.com/content/www/us/en/develop/articles/tbb-revamp.html) and the release notes and backward compatibility are reported [here](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html).
 
 To build the development version of `RcppParallel` with [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html):
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For example, installing [oneTBB](https://github.com/oneapi-src/oneTBB) on Linux 
 - Build the development version of `RcppParallel`:
 ```
 install.packages("remotes")
-remotes::install_github("hsbadr/RcppParallel@develop", force = TRUE)
+remotes::install_github("RcppCore/RcppParallel@develop", force = TRUE)
 ```
 
 ### License

--- a/README.md
+++ b/README.md
@@ -36,13 +36,6 @@ For example, installing [oneTBB](https://github.com/oneapi-src/oneTBB) on Linux 
 
     export TBB_INC="$TBB/include"
     export TBB_LIB="$TBB/lib/intel64/gcc4.8"
-    #export LD_LIBRARY_PATH="$TBB_LIB:$LD_LIBRARY_PATH"
-
-    # Checks:
-    ls -lAh $TBB_INC
-    # should list `oneapi` and `tbb` directories that include the headers
-    ls -lAh $TBB_LIB
-    # should list the TBB libraries, including `libtbb.so`
 ```
 
 - Build the development version of `RcppParallel`:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,47 @@ The high level interface enables safe and robust parallel programming without di
 
 For additional documentation on using RcppParallel see the package website at http://rcppcore.github.io/RcppParallel/.
 
+### Intel TBB
+
+`RcppParallel` now supports the new interface of Intel TBB and allows using external library (e.g., with [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html)), using `TBB_LIB` and `TBB_INC` environment variables. The updated TBB functionality are summarized [here](https://software.intel.com/content/www/us/en/develop/articles/tbb-revamp.html) and the release notes and backward compatibility are reported [here](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html).
+
+To build the development version of `RcppParallel` with [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html):
+
+- Install [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html).
+
+For example, installing [oneTBB](https://github.com/oneapi-src/oneTBB) on Linux 64-bit (`x86_64`) to `$HOME` directory (change if needed!):
+```
+    TBB_VERSION="2021.1.1"
+
+    wget https://github.com/oneapi-src/oneTBB/releases/download/v2021.1.1/oneapi-tbb-$TBB_VERSION-lin.tgz
+    tar zxvf oneapi-tbb-$TBB_VERSION-lin.tgz -C $HOME
+
+    export TBB="$HOME/oneapi-tbb-$TBB_VERSION"
+```
+
+- Set the TBB environment variables (specifically: `TBB` for the installation prefix, `TBB_INC` for the directory that includes the header files, and `TBB_LIB` for the libraries directory).
+
+For example, installing [oneTBB](https://github.com/oneapi-src/oneTBB) on Linux 64-bit (`x86_64`) to `$HOME` directory (change if needed!):
+```
+    source $TBB/env/vars.sh intel64
+
+    export TBB_INC="$TBB/include"
+    export TBB_LIB="$TBB/lib/intel64/gcc4.8"
+    #export LD_LIBRARY_PATH="$TBB_LIB:$LD_LIBRARY_PATH"
+
+    # Checks:
+    ls -lAh $TBB_INC
+    # should list `oneapi` and `tbb` directories that include the headers
+    ls -lAh $TBB_LIB
+    # should list the TBB libraries, including `libtbb.so`
+```
+
+- Build the development version of `RcppParallel`:
+```
+install.packages("remotes")
+remotes::install_github("hsbadr/RcppParallel@develop", force = TRUE)
+```
+
 ### License
 
 The RcppParallel package is made available under the [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html).

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,7 +1,7 @@
 RcppParallel 5.1.0 (UNRELEASED)
 ------------------------------------------------------------------------
 
-* Added support for external TBB library via TBB_INC and/or TBB_LIB environment variables.
+* Added support for external TBB library using TBB_INC and TBB_LIB environment variables.
 * Added support for the latest versions of Intel oneAPI TBB / oneTBB.
 * Updated TBB functionality for the new interface.
 * Falling back to building TBB from local source code.

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -2,6 +2,7 @@ RcppParallel 5.1.0 (UNRELEASED)
 ------------------------------------------------------------------------
 
 * Added support for external TBB library via TBB_INC and/or TBB_LIB environment variables.
+* Added support for the latest versions of Intel oneAPI TBB / oneTBB.
 * Updated TBB functionality for the new interface.
 * Falling back to building TBB from local source code.
 * Backward TBB compatibility based on `__TBB_tbb_stddef_H`.

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -104,6 +104,7 @@ ifdef TBB_LIB
 	rm -Rf ../inst/include/tbb_local/; \
 	mkdir -p ../inst/include; \
 	cp -R $(TBB_INC)/serial ../inst/include/ 2>/dev/null || :; \
+	cp -R $(TBB_INC)/oneapi ../inst/include/ 2>/dev/null || :; \
 	cp -R $(TBB_INC)/tbb ../inst/include/ 2>/dev/null || :
 else
 	echo "Building TBB library from source code..."; \


### PR DESCRIPTION
This builds on #141 to support for the latest versions of Intel  [oneTBB](https://github.com/oneapi-src/oneTBB) / [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html) and closes #145.

> The latest version of oneAPI/oneTBB redirects the TBB headers to a relative path (`#include "../oneapi/tbb.h"`) and we copy `tbb` headers in `inst/include/tbb` without the headers in `oneapi`. This causes a `Catastrophic Error` (missing headers) because the relative path doesn't exist.

So, make sure that we copy TBB headers in `$TBB_INC/oneapi`.

- [X] Updated `Makevars.in` to copy `oneapi` TBB headers and fix building errors.
- [X] Added instructions for using external TBB library.
- [X] Updated NEWS.

## Tests

To build the development version of `RcppParallel` with [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html):

- Install [oneTBB](https://github.com/oneapi-src/oneTBB) or [OneAPI](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-toolkit-release-notes.html).

For example, installing [oneTBB](https://github.com/oneapi-src/oneTBB) on Linux 64-bit (`x86_64`) to `$HOME` directory (change if needed!):
```
    TBB_VERSION="2021.1.1"

    wget https://github.com/oneapi-src/oneTBB/releases/download/v2021.1.1/oneapi-tbb-$TBB_VERSION-lin.tgz
    tar zxvf oneapi-tbb-$TBB_VERSION-lin.tgz -C $HOME

    export TBB="$HOME/oneapi-tbb-$TBB_VERSION"
```

- Set the TBB environment variables (specifically: `TBB` for the installation prefix, `TBB_INC` for the directory that includes the header files, and `TBB_LIB` for the libraries directory).

For example, installing [oneTBB](https://github.com/oneapi-src/oneTBB) on Linux 64-bit (`x86_64`) to `$HOME` directory (change if needed!):
```
    source $TBB/env/vars.sh intel64

    export TBB_INC="$TBB/include"
    export TBB_LIB="$TBB/lib/intel64/gcc4.8"
    #export LD_LIBRARY_PATH="$TBB_LIB:$LD_LIBRARY_PATH"

    # Checks:
    ls -lAh $TBB_INC
    # should list `oneapi` and `tbb` directories that include the headers
    ls -lAh $TBB_LIB
    # should list the TBB libraries, including `libtbb.so`
```

- Build the development version of `RcppParallel`:
```
install.packages("remotes")
remotes::install_github("hsbadr/RcppParallel@develop", force = TRUE)
```