### PR TITLE
Get rid of TBB_INTERFACE_NEW macro

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -50,12 +50,7 @@ tbbCxxFlags <- function() {
 
    if (dir.exists(Sys.getenv("TBB_INC"))) {
        TBB_INC <- asBuildPath(Sys.getenv("TBB_INC"))
-
-       if (file.exists(file.path(TBB_INC, "tbb", "version.h"))) {
-          flags <- paste0("-I", shQuote(TBB_INC), " -DTBB_INTERFACE_NEW")
-       } else {
-          flags <- paste0("-I", shQuote(TBB_INC))
-       }
+       flags <- paste0("-I", shQuote(TBB_INC))
    }
 
    flags


### PR DESCRIPTION
`TBB_INTERFACE_NEW` macro was introduced to check the new TBB interface,
whcih is not needed anymore. We can generally use `__TBB_tbb_stddef_H` macro
that is defined by `tbb/tbb_stddef.h` and is removed in the new interface,

This reverts commit f971883b7deb7ed9931b1399d81008515e4860c0.