### PR TITLE
Fix compilation on Apple Silicon

### DIFF
--- a/src/tbb/build/macos.inc
+++ b/src/tbb/build/macos.inc
@@ -40,10 +40,14 @@ ifndef arch
      export arch:=ppc32
    endif
  else
-   ifeq ($(shell /usr/sbin/sysctl -n hw.optional.x86_64 2>/dev/null),1)
-     export arch:=intel64
+   ifeq ($(shell /usr/sbin/sysctl -n hw.machine),arm64)
+     export arch:=arm64
    else
-     export arch:=ia32
+     ifeq ($(shell /usr/sbin/sysctl -n hw.optional.x86_64 2>/dev/null),1)
+       export arch:=intel64
+     else
+       export arch:=ia32
+     endif
    endif
  endif
 endif


### PR DESCRIPTION
This change, from https://github.com/oneapi-src/oneTBB/commit/86f6dcdc17a8f5ef2382faaef860cfa5243984fe.patch, fixes compilation on Apple Silicon. 

See https://github.com/RcppCore/RcppParallel/issues/137