### PR TITLE
updated skeleton generator (fixes #172)

### DIFF
--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -71,9 +71,12 @@ RcppParallel.package.skeleton <- function(name = "anRpackage",
    on.exit(setwd(owd), add = TRUE)
    
    # remove dummy stuff
-   unlink("data/dummy.Rda")
+   unlink("data", recursive=TRUE)
    unlink("man/dummy.Rd")
    unlink("Read-and-delete-me")
+   lns <- readLines("NAMESPACE")
+   writeLines(lns[!grepl("dummy", lns)], "NAMESPACE")
+   unlink("src/init.c")
    
    message("\nAdding RcppParallel settings")
    


### PR DESCRIPTION
This PR updates the skeleton generator to also remove `dummy` from `NAMESPACE`, is more rigorous with respect to `data/` (as the file ends in `.rda` here, not `.Rda`), removes that directory too, and also removes a defunct empty `src/init.c` (do we know who/what creates that ?).  

Is doesn't touch the actual Windows build faulted in #172 but I cannot reproduce failure at the Windows builder of RHub.