### PR TITLE
avoid using std::iterator

### DIFF
--- a/src/tbb/include/tbb/compat/iterator.h
+++ b/src/tbb/include/tbb/compat/iterator.h
@@ -1,0 +1,29 @@
+
+#ifndef TBB_COMPAT_ITERATOR_H
+#define TBB_COMPAT_ITERATOR_H
+
+#include <cstddef>
+
+#include <iterator>
+
+namespace tbb {
+
+template <
+    typename Category,
+    typename T,
+    typename Distance = std::ptrdiff_t,
+    typename Pointer = T*,
+    typename Reference = T& 
+> struct iterator
+{
+    using iterator_category = Category;
+    using value_type = T;
+    using difference_type = Distance;
+    using pointer = Pointer;
+    using reference = Reference;
+};
+
+} // end namespace tbb
+
+#endif
+

--- a/src/tbb/include/tbb/concurrent_hash_map.h
+++ b/src/tbb/include/tbb/concurrent_hash_map.h
@@ -23,6 +23,7 @@
 #include <cstring>      // Need std::memset
 #include __TBB_STD_SWAP_HEADER
 
+#include "compat/iterator.h"
 #include "tbb_allocator.h"
 #include "spin_rw_mutex.h"
 #include "atomic.h"
@@ -340,7 +341,7 @@ namespace interface5 {
         @ingroup containers */
     template<typename Container, typename Value>
     class hash_map_iterator
-        : public std::iterator<std::forward_iterator_tag,Value>
+        : public tbb::iterator<std::forward_iterator_tag,Value>
     {
         typedef Container map_type;
         typedef typename Container::node node;

--- a/src/tbb/include/tbb/enumerable_thread_specific.h
+++ b/src/tbb/include/tbb/enumerable_thread_specific.h
@@ -17,6 +17,8 @@
 #ifndef __TBB_enumerable_thread_specific_H
 #define __TBB_enumerable_thread_specific_H
 
+#include "compat/iterator.h"
+
 #include "atomic.h"
 #include "concurrent_vector.h"
 #include "tbb_thread.h"
@@ -296,7 +298,7 @@ namespace interface6 {
         class enumerable_thread_specific_iterator
 #if defined(_WIN64) && defined(_MSC_VER)
             // Ensure that Microsoft's internal template function _Val_type works correctly.
-            : public std::iterator<std::random_access_iterator_tag,Value>
+            : public tbb::iterator<std::random_access_iterator_tag,Value>
 #endif /* defined(_WIN64) && defined(_MSC_VER) */
         {
             //! current position in the concurrent_vector
@@ -458,7 +460,7 @@ namespace interface6 {
     template<typename SegmentedContainer, typename Value >
         class segmented_iterator
 #if defined(_WIN64) && defined(_MSC_VER)
-        : public std::iterator<std::input_iterator_tag, Value>
+        : public tbb::iterator<std::input_iterator_tag, Value>
 #endif
         {
             template<typename C, typename T, typename U>

--- a/src/tbb/include/tbb/internal/_concurrent_queue_impl.h
+++ b/src/tbb/include/tbb/internal/_concurrent_queue_impl.h
@@ -21,6 +21,8 @@
 #error Do not #include this internal file directly; use public TBB headers instead.
 #endif
 
+#include "../compat/iterator.h"
+
 #include "../tbb_stddef.h"
 #include "../tbb_machine.h"
 #include "../atomic.h"
@@ -741,7 +743,7 @@ template<typename T> struct tbb_remove_cv<const volatile T> {typedef T type;};
     @ingroup containers */
 template<typename Container, typename Value>
 class concurrent_queue_iterator: public concurrent_queue_iterator_base_v3<typename tbb_remove_cv<Value>::type>,
-        public std::iterator<std::forward_iterator_tag,Value> {
+        public tbb::iterator<std::forward_iterator_tag,Value> {
 #if !__TBB_TEMPLATE_FRIENDS_BROKEN
     template<typename T, class A>
     friend class ::tbb::strict_ppl::concurrent_queue;
@@ -1000,7 +1002,7 @@ typedef concurrent_queue_iterator_base_v3 concurrent_queue_iterator_base;
     @ingroup containers */
 template<typename Container, typename Value>
 class concurrent_queue_iterator: public concurrent_queue_iterator_base,
-        public std::iterator<std::forward_iterator_tag,Value> {
+        public tbb::iterator<std::forward_iterator_tag,Value> {
 
 #if !__TBB_TEMPLATE_FRIENDS_BROKEN
     template<typename T, class A>

--- a/src/tbb/include/tbb/internal/_concurrent_unordered_impl.h
+++ b/src/tbb/include/tbb/internal/_concurrent_unordered_impl.h
@@ -32,6 +32,8 @@
 #include <cstring>      // Need std::memset
 #include __TBB_STD_SWAP_HEADER
 
+#include "../compat/iterator.h"
+
 #include "../atomic.h"
 #include "../tbb_exception.h"
 #include "../tbb_allocator.h"
@@ -64,7 +66,7 @@ class concurrent_unordered_base;
 
 // Forward list iterators (without skipping dummy elements)
 template<class Solist, typename Value>
-class flist_iterator : public std::iterator<std::forward_iterator_tag, Value>
+class flist_iterator : public tbb::iterator<std::forward_iterator_tag, Value>
 {
     template <typename T, typename Allocator>
     friend class split_ordered_list;

--- a/src/tbb/src/tbbmalloc/proxy.cpp
+++ b/src/tbb/src/tbbmalloc/proxy.cpp
@@ -14,6 +14,16 @@
     limitations under the License.
 */
 
+#ifdef __GNUC__
+# if __GNUC__ >= 12
+#  define TBB_ALIAS(x) __attribute__((alias(#x), copy(x)))
+# endif
+#endif
+
+#ifndef TBB_ALIAS
+# define TBB_ALIAS(x) __attribute__((alias(#x)))
+#endif
+
 #if __linux__ && !__ANDROID__
 // include <bits/c++config.h> indirectly so that <cstdlib> is not included
 #include <cstddef>
@@ -146,7 +156,7 @@ static inline void initPageSize()
    1) detection that the proxy library is loaded
    2) check that dlsym("malloc") found something different from our replacement malloc
 */
-extern "C" void *__TBB_malloc_proxy(size_t) __attribute__ ((alias ("malloc")));
+extern "C" void *__TBB_malloc_proxy(size_t) TBB_ALIAS(malloc);
 
 static void *orig_msize;
 
@@ -285,19 +295,19 @@ struct mallinfo mallinfo() __THROW
 // Android doesn't have malloc_usable_size, provide it to be compatible
 // with Linux, in addition overload dlmalloc_usable_size() that presented
 // under Android.
-size_t dlmalloc_usable_size(const void *ptr) __attribute__ ((alias ("malloc_usable_size")));
+size_t dlmalloc_usable_size(const void *ptr) TBB_ALIAS(malloc_usable_size);
 #else // __ANDROID__
 // C11 function, supported starting GLIBC 2.16
-void *aligned_alloc(size_t alignment, size_t size) __attribute__ ((alias ("memalign")));
+void *aligned_alloc(size_t alignment, size_t size) TBB_ALIAS(memalign);
 // Those non-standard functions are exported by GLIBC, and might be used
 // in conjunction with standard malloc/free, so we must ovberload them.
 // Bionic doesn't have them. Not removing from the linker scripts,
 // as absent entry points are ignored by the linker.
-void *__libc_malloc(size_t size) __attribute__ ((alias ("malloc")));
-void *__libc_calloc(size_t num, size_t size) __attribute__ ((alias ("calloc")));
-void *__libc_memalign(size_t alignment, size_t size) __attribute__ ((alias ("memalign")));
-void *__libc_pvalloc(size_t size) __attribute__ ((alias ("pvalloc")));
-void *__libc_valloc(size_t size) __attribute__ ((alias ("valloc")));
+void *__libc_malloc(size_t size) TBB_ALIAS(malloc);
+void *__libc_calloc(size_t num, size_t size) TBB_ALIAS(calloc);
+void *__libc_memalign(size_t alignment, size_t size) TBB_ALIAS(memalign);
+void *__libc_pvalloc(size_t size) TBB_ALIAS(pvalloc);
+void *__libc_valloc(size_t size) TBB_ALIAS(valloc);
 
 // call original __libc_* to support naive replacement of free via __libc_free etc
 void __libc_free(void *ptr)

--- a/src/tbb/src/test/test_container_move_support.h
+++ b/src/tbb/src/test/test_container_move_support.h
@@ -22,6 +22,8 @@
 #include "harness_allocator.h"
 #include "harness_state_trackable.h"
 
+#include "tbb/compat/iterator.h"
+
 #include "tbb/atomic.h"
 #include "tbb/aligned_space.h"
 #include "tbb/internal/_allocator_traits.h"
@@ -172,7 +174,7 @@ public:
     friend bool operator!=(const FooIteratorType & lhs, const FooIteratorType & rhs){ return !(lhs == rhs); }
 };
 
-class FooIterator: public std::iterator<std::input_iterator_tag,FooWithAssign>, public FooIteratorBase<FooIterator> {
+class FooIterator: public tbb::iterator<std::input_iterator_tag,FooWithAssign>, public FooIteratorBase<FooIterator> {
 public:
     FooIterator(intptr_t x): FooIteratorBase<FooIterator>(x) {}
 
@@ -181,7 +183,7 @@ public:
     }
 };
 
-class FooPairIterator: public std::iterator<std::input_iterator_tag, std::pair<FooWithAssign,FooWithAssign> >,  public FooIteratorBase<FooPairIterator> {
+class FooPairIterator: public tbb::iterator<std::input_iterator_tag, std::pair<FooWithAssign,FooWithAssign> >,  public FooIteratorBase<FooPairIterator> {
 public:
     FooPairIterator(intptr_t x): FooIteratorBase<FooPairIterator>(x) {}
 


### PR DESCRIPTION
Provide a simple `std::iterator<>` implementation that lets us avoid C++17 deprecation warnings.