### PR TITLE
Fix strict linking on MacOS

### DIFF
--- a/R/platform.R
+++ b/R/platform.R
@@ -3,6 +3,10 @@ is_windows <- function() {
    .Platform$OS.type == "windows"
 }
 
+is_mac <- function() {
+   Sys.info()[["sysname"]] == "Darwin"
+}
+
 is_unix <- function() {
    .Platform$OS.type == "unix"
 }

--- a/R/tbb.R
+++ b/R/tbb.R
@@ -81,8 +81,8 @@ tbbLdFlags <- function() {
       return(sprintf(fmt, asBuildPath(tbbLib)))
    }
    
-   # on Windows and Solaris, we need to explicitly link
-   needsExplicitFlags <- is_windows() || (is_solaris() && !is_sparc())
+   # on Mac, Windows and Solaris, we need to explicitly link (#206)
+   needsExplicitFlags <- is_mac() || is_windows() || (is_solaris() && !is_sparc())
    if (needsExplicitFlags) {
       libPath <- asBuildPath(tbbLibraryPath())
       libFlag <- paste0("-L", libPath)

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -95,6 +95,11 @@ ifneq (@COMPILER@, )
 	MAKE_ARGS += compiler=@COMPILER@
 endif
 
+# When TBB_LIB is unset on MacOS, link to the bundled version (#206)
+ifeq ($(USE_TBB)$(TBB_LIB),Mac)
+	PKG_LIBS += -Ltbb/build/lib_release -ltbb -ltbbmalloc
+endif
+
 # For Solaris detect if this is 32-bit R on x86 and if so forward that to TBB
 ifeq ($(USE_TBB), SunOS)
 	R_32BIT = $(shell ${R_HOME}/bin/Rscript -e 'cat(.Machine$$sizeof.pointer == 4)')

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -97,7 +97,7 @@ endif
 
 # When TBB_LIB is unset on MacOS, link to the bundled version (#206)
 ifeq ($(USE_TBB)$(TBB_LIB),Mac)
-	PKG_LIBS += -Ltbb/build/lib_release -ltbb -ltbbmalloc
+	PKG_LIBS += -Ltbb/build/lib_release -ltbb -Wl,-rpath,'@loader_path/../lib'
 endif
 
 # For Solaris detect if this is 32-bit R on x86 and if so forward that to TBB


### PR DESCRIPTION
Fixes #206.

This basically does the same as you already did on Windows here:

https://github.com/RcppCore/RcppParallel/blob/6f817167216e8954670ce8aba1c4fc732ff0da82/src/Makevars.in#L87-L89

And likewise in `tbbLdFlags()`. 


In my own fork I added CI for Mac, so you can see that it failed on MacOS before this fix, and then passed afterwards: https://github.com/jeroen/RcppParallel/commits/master/