### PR TITLE
Two small tweaks for cross compiling

### DIFF
--- a/R/tbb.R
+++ b/R/tbb.R
@@ -75,7 +75,7 @@ tbbCxxFlags <- function() {
 tbbLdFlags <- function() {
    
    # shortcut if TBB_LIB defined
-   tbbLib <- Sys.getenv("TBB_LIB", unset = TBB_LIB)
+   tbbLib <- Sys.getenv("TBB_LINK_LIB", Sys.getenv("TBB_LIB", unset = TBB_LIB))
    if (nzchar(tbbLib)) {
       fmt <- "-L%1$s -Wl,-rpath,%1$s -ltbb -ltbbmalloc"
       return(sprintf(fmt, asBuildPath(tbbLib)))

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -40,6 +40,7 @@ else
 
 	ifeq ($(UNAME), Darwin)
 		USE_TBB=Mac
+		MAKE_ARGS += arch=$(shell uname -m)
 	endif
 
 	ifeq ($(UNAME), Linux)


### PR DESCRIPTION
Two more tiny tweaks that will smoothen the cross compile process:

First the `arch` detection in libtbb relies on `/usr/sbin/sysctl` which does not work on linux or macos-cross. As a result it ends up falling back on `arch=ia32` which is completely wrong.

https://github.com/RcppCore/RcppParallel/blob/d4573c1479f35b611d470931c924ee9ac851b2ae/src/tbb/build/macos.inc#L30-L50

The robust way to detect the target arch on Mac is `uname -m` (the cross environments shim `uname` to return the target). So we pre-set that in the RcppParallel Makevars, the same way as is done for Windows.

And one final tweak: we introduce a variable `TBB_LINK_LIB` that we can use to set the location of the target libtbb, without affecting the runtime TBB. If the variable is unset, the current behavior remains the same.

This is needed, because when we cross compile packages that link against RcppParallel, we need have two copies of RcppParallel: one on the host architecture, that is use to load RcppParallel in order to call `RcppParallel::RcppParallelLibs()`. And then we need a separate installation of RcppParallel for the cross target architecture, that the package we are building should link against.

Currently we have no way of doing this: if we set `TBB_LIB` to the cross target arch, the RcppParallel won't load, but if we set it to the host (or we leave it undefined) the path returned by `RcppParallel::RcppParallelLibs()` returns the host architecture and gives a linking error for the cross build.
