### PR TITLE
undef TRUE and FALSE macros

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,17 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: windows-latest, r: 'release'}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RcppParallel
 Type: Package
 Title: Parallel Programming Tools for 'Rcpp'
-Version: 5.1.7-9000
+Version: 5.1.7-9001
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut"), email = "jj@rstudio.com"),
     person("Romain", "Francois", role = c("aut", "cph")),

--- a/inst/include/RcppParallel.h
+++ b/inst/include/RcppParallel.h
@@ -69,4 +69,14 @@ inline void parallelReduce(std::size_t begin,
 
 } // end namespace RcppParallel
 
+// TRUE and FALSE macros that may come with system headers on some systems
+// But conflict with R.h (R_ext/Boolean.h)
+// TRUE and FALSE macros should be undef in RcppParallel.h
+#ifdef TRUE
+  #undef TRUE
+#endif
+#ifdef FALSE
+  #undef FALSE
+#endif
+
 #endif // __RCPP_PARALLEL__

--- a/inst/tests/cpp/truefalse_macros.cpp
+++ b/inst/tests/cpp/truefalse_macros.cpp
@@ -1,0 +1,31 @@
+/**
+ * @title Test for TRUE and FALSE macros
+ * @author Travers Ching
+ * @license GPL (>= 2)
+ */
+
+// TRUE and FALSE macros that may come with system headers on some systems
+// But conflict with R.h (R_ext/Boolean.h)
+// TRUE and FALSE macros should be undef in RcppParallel.h
+
+#include <Rcpp.h>
+#include <RcppParallel.h>
+
+// [[Rcpp::depends(RcppParallel)]]
+
+#ifndef TRUE
+static_assert(true, "Macro TRUE does not exist");
+#else
+static_assert(false, "Macro TRUE exists");
+#endif
+
+#ifndef FALSE
+static_assert(true, "Macro FALSE does not exist");
+#else
+static_assert(false, "Macro FALSE exists");
+#endif
+
+// [[Rcpp::export]]
+int hush_no_export_warning() {
+  return 1;
+}

--- a/inst/tests/runit.truefalse_macros.R
+++ b/inst/tests/runit.truefalse_macros.R
@@ -1,0 +1,6 @@
+
+library(Rcpp)
+library(RUnit)
+
+sourceCpp(system.file("tests/cpp/truefalse_macros.cpp", package = "RcppParallel"))
+


### PR DESCRIPTION
Referencing https://github.com/RcppCore/RcppParallel/issues/210

I added undef statements in RcppParallel.h and added a unit test to make sure they are gone. I also went ahead and added Mac and Windows to github actions, since the problem only appears on Mac and Windows. 

Here is a purposeful failure on Mac and Windows github actions if you were to remove the undef statements:

https://github.com/traversc/RcppParallel/tree/fail_on_mac