### PR TITLE
Support building TBB on Windows arm64

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^tests/testthat/pkg/RcppParallelTest/src/.*\.s?o$
 ^tools/tbb$
 ^\.github$
+^patches

--- a/R/tbb.R
+++ b/R/tbb.R
@@ -81,10 +81,6 @@ tbbLdFlags <- function() {
       return(sprintf(fmt, asBuildPath(tbbLib)))
    }
    
-   # on Aarch64 builds, use the version of TBB provided by Rtools
-   if (is_windows() && R.version$arch == "aarch64")
-      return("-ltbb12 -ltbbmalloc")
-   
    # on Mac, Windows and Solaris, we need to explicitly link (#206)
    needsExplicitFlags <- is_mac() || is_windows() || (is_solaris() && !is_sparc())
    if (needsExplicitFlags) {

--- a/R/tbb.R
+++ b/R/tbb.R
@@ -49,8 +49,14 @@ tbbCxxFlags <- function() {
    flags <- character()
    
    # opt-in to TBB on Windows
-   if (is_windows())
+   if (is_windows()) {
       flags <- c(flags, "-DRCPP_PARALLEL_USE_TBB=1")
+      if (R.version$arch == "aarch64") {
+         # TBB does not have assembly code for Windows ARM64
+         # so we need to use compiler builtins
+         flags <- c(flags, "-DTBB_USE_GCC_BUILTINS")
+      }
+   }
    
    # if TBB_INC is set, apply those library paths
    tbbInc <- Sys.getenv("TBB_INC", unset = TBB_INC)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -27,12 +27,8 @@ loadTbbLibrary <- function(name) {
 
 .onLoad <- function(libname, pkgname) {
    
-   tbbLibraryName <- "tbb"
-   if (is_windows() && R.version$arch == "aarch64")
-      tbbLibraryName <- "tbb12"
-   
    # load tbb, tbbmalloc
-   .tbbDllInfo       <<- loadTbbLibrary(tbbLibraryName)
+   .tbbDllInfo       <<- loadTbbLibrary("tbb")
    .tbbMallocDllInfo <<- loadTbbLibrary("tbbmalloc")
    
    # load tbbmalloc_proxy, but only if requested

--- a/inst/include/RcppParallel.h
+++ b/inst/include/RcppParallel.h
@@ -18,6 +18,9 @@
 #endif
 
 #if RCPP_PARALLEL_USE_TBB
+#if defined(WINNT) && defined(__aarch64__) && !defined(TBB_USE_GCC_BUILTINS)
+#define TBB_USE_GCC_BUILTINS 1
+#endif
 # include "RcppParallel/TBB.h"
 #endif
 

--- a/patches/windows_arm64.diff
+++ b/patches/windows_arm64.diff
@@ -1,0 +1,47 @@
+diff --git a/src/tbb/build/Makefile.tbb b/src/tbb/build/Makefile.tbb
+index 8d155f80..c58f4fb1 100644
+--- a/src/tbb/build/Makefile.tbb
++++ b/src/tbb/build/Makefile.tbb
+@@ -91,7 +91,11 @@ ifneq (,$(TBB.DEF))
+ tbb.def: $(TBB.DEF) $(TBB.LST)
+ 	$(CPLUS) $(PREPROC_ONLY) $< $(CPLUS_FLAGS) $(INCLUDES) > $@
+ 
+-LIB_LINK_FLAGS += $(EXPORT_KEY)tbb.def
++# LLVM on Windows doesn't need --version-script export
++# https://reviews.llvm.org/D63743
++ifeq (, $(WINARM64_CLANG))
++  LIB_LINK_FLAGS += $(EXPORT_KEY)tbb.def
++endif
+ $(TBB.DLL): tbb.def
+ endif
+ 
+diff --git a/src/tbb/build/Makefile.tbbmalloc b/src/tbb/build/Makefile.tbbmalloc
+index 421e95c5..e7c38fa4 100644
+--- a/src/tbb/build/Makefile.tbbmalloc
++++ b/src/tbb/build/Makefile.tbbmalloc
+@@ -74,7 +74,11 @@ ifneq (,$(MALLOC.DEF))
+ tbbmalloc.def: $(MALLOC.DEF)
+ 	$(CPLUS) $(PREPROC_ONLY) $< $(M_CPLUS_FLAGS) $(WARNING_SUPPRESS) $(INCLUDES) > $@
+ 
+-MALLOC_LINK_FLAGS += $(EXPORT_KEY)tbbmalloc.def
++# LLVM on Windows doesn't need --version-script export
++# https://reviews.llvm.org/D63743
++ifeq (, $(WINARM64_CLANG))
++	MALLOC_LINK_FLAGS += $(EXPORT_KEY)tbbmalloc.def
++endif
+ $(MALLOC.DLL): tbbmalloc.def
+ endif
+ 
+diff --git a/src/tbb/src/tbbmalloc/TypeDefinitions.h b/src/tbb/src/tbbmalloc/TypeDefinitions.h
+index 3178442e..fd4b7956 100644
+--- a/src/tbb/src/tbbmalloc/TypeDefinitions.h
++++ b/src/tbb/src/tbbmalloc/TypeDefinitions.h
+@@ -25,7 +25,7 @@
+ #       define __ARCH_ipf 1
+ #   elif defined(_M_IX86)||defined(__i386__) // the latter for MinGW support
+ #       define __ARCH_x86_32 1
+-#   elif defined(_M_ARM)
++#   elif defined(_M_ARM) || defined(__aarch64__)
+ #       define __ARCH_other 1
+ #   else
+ #       error Unknown processor architecture for Windows

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -21,6 +21,14 @@ ifeq ($(OS), Windows_NT)
 	USE_TBB=Windows
 	TBB_COPY_PATTERN=tbb*.dll
 
+	ARCH=$(shell "${R_HOME}/bin/R" --vanilla -s -e 'cat(R.version$$arch)')
+	TBB_CXXFLAGS = @CXX11FLAGS@ -DTBB_NO_LEGACY=1
+	ifeq "$(ARCH)" "aarch64"
+		WINARM64=true
+		PKG_CPPFLAGS += -DTBB_USE_GCC_BUILTINS
+		TBB_CXXFLAGS += -DTBB_USE_GCC_BUILTINS
+	endif
+
 	MAKE = make
 	MAKEFLAGS = -e -j1
 	MAKE_CMD =                                    \
@@ -28,9 +36,10 @@ ifeq ($(OS), Windows_NT)
 		CYGWIN=nodosfilewarning                   \
 		CONLY="@WINDOWS_CC@"                      \
 		CPLUS="@WINDOWS_CXX11@"                   \
-		CXXFLAGS="@CXX11FLAGS@ -DTBB_NO_LEGACY=1" \
+		CXXFLAGS="$(TBB_CXXFLAGS)" 				  \
 		PIC_KEY="@CXX11PICFLAGS@"                 \
 		WARNING_SUPPRESS=""                       \
+		WINARM64="$(WINARM64)"                    \
 		$(MAKE)
 
 else
@@ -77,26 +86,19 @@ ifeq ($(USE_TBB), Windows)
 	# rtools: turn on hacks to compensate for make and shell differences rtools<=>MinGW
 	# compiler: overwrite default (which is cl = MS compiler)
 	MAKE_ARGS += rtools=true compiler=gcc
-	ifeq ($(WIN), 64)
-		MAKE_ARGS += arch=intel64 runtime=mingw
-		ARCH_DIR=x64/
-	else
-		MAKE_ARGS += arch=ia32 runtime=mingw
-		ARCH_DIR=i386/
+	ifneq ($(WINARM64), true)
+		ifeq ($(WIN), 64)
+			MAKE_ARGS += arch=intel64 runtime=mingw
+			ARCH_DIR=x64/
+		else
+			MAKE_ARGS += arch=ia32 runtime=mingw
+			ARCH_DIR=i386/
+		endif
 	endif
 
 	# Linker needs access to the tbb dll; otherwise you get errors such as:
 	# "undefined reference to `tbb::task_scheduler_init::terminate()'"
 	PKG_LIBS += -Ltbb/build/lib_release -ltbb -ltbbmalloc
-	
-	# override for aarch64 (experimental) to use Rtools TBB
-	ARCH=$(shell "${R_HOME}/bin/R" --vanilla -s -e 'cat(R.version$$arch)')
-	ifeq "$(ARCH)" "aarch64"
-		TBB_LIB = ${R_TOOLS_SOFT}
-		TBB_INC = ${R_TOOLS_SOFT}
-		PKG_LIBS = -ltbb12 -ltbbmalloc
-	endif
-
 endif
 
 # write compiler if set

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -24,9 +24,12 @@ ifeq ($(OS), Windows_NT)
 	ARCH=$(shell "${R_HOME}/bin/R" --vanilla -s -e 'cat(R.version$$arch)')
 	TBB_CXXFLAGS = @CXX11FLAGS@ -DTBB_NO_LEGACY=1
 	ifeq "$(ARCH)" "aarch64"
-		WINARM64=true
 		PKG_CPPFLAGS += -DTBB_USE_GCC_BUILTINS
 		TBB_CXXFLAGS += -DTBB_USE_GCC_BUILTINS
+		CLANG_CHECK := $(shell echo | $(CC) -E -dM -  | findstr __clang__)
+		ifneq ($(CLANG_CHECK), )
+			WINARM64_CLANG=true
+		endif
 	endif
 
 	MAKE = make
@@ -39,7 +42,7 @@ ifeq ($(OS), Windows_NT)
 		CXXFLAGS="$(TBB_CXXFLAGS)" 				  \
 		PIC_KEY="@CXX11PICFLAGS@"                 \
 		WARNING_SUPPRESS=""                       \
-		WINARM64="$(WINARM64)"                    \
+		WINARM64_CLANG="$(WINARM64_CLANG)"        \
 		$(MAKE)
 
 else
@@ -86,7 +89,9 @@ ifeq ($(USE_TBB), Windows)
 	# rtools: turn on hacks to compensate for make and shell differences rtools<=>MinGW
 	# compiler: overwrite default (which is cl = MS compiler)
 	MAKE_ARGS += rtools=true compiler=gcc
-	ifneq ($(WINARM64), true)
+	# TBB configure will detect mingw runtime with unknown arch on WINARM64_CLANG but not an 
+	#   issue as we are using compiler built-ins instead of arch-specific code
+	ifneq ($(WINARM64_CLANG), true)
 		ifeq ($(WIN), 64)
 			MAKE_ARGS += arch=intel64 runtime=mingw
 			ARCH_DIR=x64/

--- a/src/tbb/build/Makefile.tbb
+++ b/src/tbb/build/Makefile.tbb
@@ -91,7 +91,11 @@ ifneq (,$(TBB.DEF))
 tbb.def: $(TBB.DEF) $(TBB.LST)
 	$(CPLUS) $(PREPROC_ONLY) $< $(CPLUS_FLAGS) $(INCLUDES) > $@
 
-LIB_LINK_FLAGS += $(EXPORT_KEY)tbb.def
+# LLVM on Windows doesn't need --version-script export
+# https://reviews.llvm.org/D63743
+ifeq (, $(WINARM64))
+  LIB_LINK_FLAGS += $(EXPORT_KEY)tbb.def
+endif
 $(TBB.DLL): tbb.def
 endif
 

--- a/src/tbb/build/Makefile.tbb
+++ b/src/tbb/build/Makefile.tbb
@@ -93,7 +93,7 @@ tbb.def: $(TBB.DEF) $(TBB.LST)
 
 # LLVM on Windows doesn't need --version-script export
 # https://reviews.llvm.org/D63743
-ifeq (, $(WINARM64))
+ifeq (, $(WINARM64_CLANG))
   LIB_LINK_FLAGS += $(EXPORT_KEY)tbb.def
 endif
 $(TBB.DLL): tbb.def

--- a/src/tbb/build/Makefile.tbbmalloc
+++ b/src/tbb/build/Makefile.tbbmalloc
@@ -76,7 +76,7 @@ tbbmalloc.def: $(MALLOC.DEF)
 
 # LLVM on Windows doesn't need --version-script export
 # https://reviews.llvm.org/D63743
-ifeq (, $(WINARM64))
+ifeq (, $(WINARM64_CLANG))
 	MALLOC_LINK_FLAGS += $(EXPORT_KEY)tbbmalloc.def
 endif
 $(MALLOC.DLL): tbbmalloc.def

--- a/src/tbb/build/Makefile.tbbmalloc
+++ b/src/tbb/build/Makefile.tbbmalloc
@@ -74,7 +74,11 @@ ifneq (,$(MALLOC.DEF))
 tbbmalloc.def: $(MALLOC.DEF)
 	$(CPLUS) $(PREPROC_ONLY) $< $(M_CPLUS_FLAGS) $(WARNING_SUPPRESS) $(INCLUDES) > $@
 
-MALLOC_LINK_FLAGS += $(EXPORT_KEY)tbbmalloc.def
+# LLVM on Windows doesn't need --version-script export
+# https://reviews.llvm.org/D63743
+ifeq (, $(WINARM64))
+	MALLOC_LINK_FLAGS += $(EXPORT_KEY)tbbmalloc.def
+endif
 $(MALLOC.DLL): tbbmalloc.def
 endif
 

--- a/src/tbb/src/tbbmalloc/TypeDefinitions.h
+++ b/src/tbb/src/tbbmalloc/TypeDefinitions.h
@@ -25,7 +25,7 @@
 #       define __ARCH_ipf 1
 #   elif defined(_M_IX86)||defined(__i386__) // the latter for MinGW support
 #       define __ARCH_x86_32 1
-#   elif defined(_M_ARM)
+#   elif defined(_M_ARM) || defined(__aarch64__)
 #       define __ARCH_other 1
 #   else
 #       error Unknown processor architecture for Windows


### PR DESCRIPTION
This PR reverts the changes which delegate to RTools for the TBB on Windows ARM64, and adds support for building and using the bundled TBB. 

We use the same changes in the [Stan Math library](https://github.com/stan-dev/math/pull/3051), where the threading all performs as expected on Windows ARM64 with the RTools aarch64 toolchain.

@kalibera would you be able to verify on your system as well, when you have the time? 