### PR TITLE
Makevars.in: fix a linker flag for TBB_LIB

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -28,7 +28,7 @@ else
 endif
 
 ifdef TBB_LIB
-	PKG_LIBS = -Wl,-L,"$(TBB_LIB)" -Wl,-rpath,"$(TBB_LIB)" -ltbb -ltbbmalloc
+	PKG_LIBS = -Wl,-L"$(TBB_LIB)" -Wl,-rpath,"$(TBB_LIB)" -ltbb -ltbbmalloc
 endif
 
 ifeq ($(OS), Windows_NT)


### PR DESCRIPTION
I have no way to test this outside of macOS, so possibly this should be made macOS-specific.
On macOS this works correctly on every version (tested on 10.6 through 14.5): https://ports.macports.org/port/R-RcppParallel/details

We apply the fix unconditionally: https://github.com/macports/macports-ports/blob/3f434145bd9b0020a4385175479017c8336bbd7e/R/R-RcppParallel/Portfile#L23-L24
https://github.com/macports/macports-ports/blob/3f434145bd9b0020a4385175479017c8336bbd7e/R/R-RcppParallel/files/patch-unbreak-linking.diff