### PR TITLE
configure.R: add a case for MacPorts oneTBB headers

### DIFF
--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -56,6 +56,7 @@ if (broken)
 cppflags <- read_r_config("CPPFLAGS", envir = NULL)[[1]]
 cppflags <- sub("(?: )?-I/usr/local/include", "", cppflags)
 cppflags <- sub("(?: )?-I/opt/homebrew/include", "", cppflags)
+cppflags <- sub("(?: )?-I/opt/local/libexec/onetbb/include", "", cppflags)
 
 # define the set of flags appropriate to the current
 # configuration of R


### PR DESCRIPTION
I guess we can also have a MacPorts case there, since Homebrew is there?
Provided this is relevant for a case of bundled TBB (as follows from comment above). For using an external we do not need to drop the flag, of course.

UPD. Ah, this drops flags because RcppParallel copies headers anyway, so external should not be used in any case.