### PR TITLE
Do not attempt to use -rpath on Windows when linking.

### DIFF
--- a/R/tbb.R
+++ b/R/tbb.R
@@ -83,7 +83,8 @@ tbbLdFlags <- function() {
    # shortcut if TBB_LIB defined
    tbbLib <- Sys.getenv("TBB_LINK_LIB", Sys.getenv("TBB_LIB", unset = TBB_LIB))
    if (nzchar(tbbLib)) {
-      fmt <- "-L%1$s -Wl,-rpath,%1$s -ltbb -ltbbmalloc"
+      fmt <- if (is_windows()) "-L%1$s -ltbb -ltbbmalloc"
+             else "-L%1$s -Wl,-rpath,%1$s -ltbb -ltbbmalloc"
       return(sprintf(fmt, asBuildPath(tbbLib)))
    }
    

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -13,7 +13,11 @@ endif
 
 # If TBB_LIB is defined, link to that explicitly.
 ifdef TBB_LIB
-	PKG_LIBS = -Wl,-L"$(TBB_LIB)" -Wl,-rpath,"$(TBB_LIB)" -ltbb -ltbbmalloc
+	ifeq ($(OS), Windows_NT)
+		PKG_LIBS = -Wl,-L"$(TBB_LIB)" -ltbb -ltbbmalloc
+	else
+		PKG_LIBS = -Wl,-L"$(TBB_LIB)" -Wl,-rpath,"$(TBB_LIB)" -ltbb -ltbbmalloc
+	endif
 endif
 
 ifeq ($(OS), Windows_NT)


### PR DESCRIPTION
Windows does not support the Unix -rpath mechanism. This patch avoids attempts to use it, which is needed with LLVM lld linker, which fails with error message "unknown argument". 