### PR TITLE
interim release to help with future binary compatibility

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -37,7 +37,7 @@ loadTbbLibrary <- function(name) {
       .tbbMallocProxyDllInfo <<- loadTbbLibrary("tbbmalloc_proxy")
    
    # load RcppParallel library if available
-   .dllInfo <<- library.dynam("RcppParallel", pkgname, libname)
+   .dllInfo <<- library.dynam("RcppParallel", pkgname, libname, local = FALSE)
    
 }
 

--- a/RcppParallel.Rproj
+++ b/RcppParallel.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: f1ae2e5b-eb1d-4d93-9ae1-29e364a5eaa6
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/RcppParallel.Rproj
+++ b/RcppParallel.Rproj
@@ -13,7 +13,11 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
 BuildType: Package
-PackageInstallArgs: --with-keep.source --clean
+PackageCleanBeforeInstall: No
+PackageInstallArgs: --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/inst/include/RcppParallel/Common.h
+++ b/inst/include/RcppParallel/Common.h
@@ -15,49 +15,49 @@ inline int resolveValue(const char* envvar,
    // if the requested value is non-zero and not the default, we can use it
    if (requestedValue != defaultValue && requestedValue > 0)
       return requestedValue;
-   
+
    // otherwise, try reading the default from associated envvar
    // if the environment variable is unset, use the default
    const char* var = getenv(envvar);
    if (var == NULL)
       return defaultValue;
-   
+
    // try to convert the string to a number
    // if an error occurs during conversion, just use default
    errno = 0;
    char* end;
    long value = strtol(var, &end, 10);
-   
+
    // check for conversion failure
    if (end == var || *end != '\0' || errno == ERANGE)
       return defaultValue;
-   
-   // okay, return the parsed environment variable value   
+
+   // okay, return the parsed environment variable value
    return value;
 }
+
+// Tag type used for disambiguating splitting constructors
+struct Split {};
 
 // Work executed within a background thread. We implement dynamic
 // dispatch using vtables so we can have a stable type to cast
 // to from the void* passed to the worker thread (required because
 // the tinythreads interface allows to pass only a void* to the
 // thread main rather than a generic type / template)
-struct Worker 
-{  
+struct Worker
+{
    // construct and destruct (delete virtually)
    Worker() {}
    virtual ~Worker() {}
-   
+
    // dispatch work over a range of values
-   virtual void operator()(std::size_t begin, std::size_t end) = 0;   
-   
-   // disable copying and assignment
+   virtual void operator()(std::size_t begin, std::size_t end) = 0;
+
 private:
+   // disable copying and assignment
    Worker(const Worker&);
    void operator=(const Worker&);
 };
-
-// Tag type used for disambiguating splitting constructors
-struct Split {};
 
 // Used for controlling the stack size for threads / tasks within a scope.
 class ThreadStackSizeControl
@@ -65,7 +65,7 @@ class ThreadStackSizeControl
 public:
    ThreadStackSizeControl();
    ~ThreadStackSizeControl();
-   
+
 private:
    // COPYING: not copyable
    ThreadStackSizeControl(const ThreadStackSizeControl&);

--- a/inst/include/RcppParallel/Common.h
+++ b/inst/include/RcppParallel/Common.h
@@ -41,7 +41,6 @@ inline int resolveValue(const char* envvar,
 // to from the void* passed to the worker thread (required because
 // the tinythreads interface allows to pass only a void* to the
 // thread main rather than a generic type / template)
-
 struct Worker 
 {  
    // construct and destruct (delete virtually)
@@ -58,8 +57,21 @@ private:
 };
 
 // Tag type used for disambiguating splitting constructors
-
 struct Split {};
+
+// Used for controlling the stack size for threads / tasks within a scope.
+class ThreadStackSizeControl
+{
+public:
+   ThreadStackSizeControl();
+   ~ThreadStackSizeControl();
+   
+private:
+   // COPYING: not copyable
+   ThreadStackSizeControl(const ThreadStackSizeControl&);
+   ThreadStackSizeControl& operator=(const ThreadStackSizeControl&);
+};
+
 
 } // namespace RcppParallel
 

--- a/inst/include/RcppParallel/TBB.h
+++ b/inst/include/RcppParallel/TBB.h
@@ -13,8 +13,6 @@
 
 namespace RcppParallel {
 
-namespace {
-
 struct TBBWorker
 {
    explicit TBBWorker(Worker& worker) : worker_(worker) {}
@@ -183,46 +181,6 @@ private:
    std::size_t end_;
    std::size_t grainSize_;
 };
-
-class ThreadStackSizeControl
-{
-public:
-   
-   ThreadStackSizeControl()
-      : control_(nullptr)
-   {
-      int stackSize = resolveValue("RCPP_PARALLEL_STACK_SIZE", 0, 0);
-      if (stackSize > 0)
-      {
-         control_ = new tbb::global_control(
-            tbb::global_control::thread_stack_size,
-            stackSize
-         );
-      }
-   }
-   
-   ~ThreadStackSizeControl()
-   {
-      if (control_ != nullptr)
-      {
-         delete control_;
-         control_ = nullptr;
-      }
-   }
-
-private:
-   
-   // COPYING: not copyable
-   ThreadStackSizeControl(const ThreadStackSizeControl&);
-   ThreadStackSizeControl& operator=(const ThreadStackSizeControl&);
-   
-   // private members
-   tbb::global_control* control_;
-   
-};
-   
-} // anonymous namespace
-
 
 inline void tbbParallelFor(std::size_t begin,
                            std::size_t end, 

--- a/inst/include/RcppParallel/TBB.h
+++ b/inst/include/RcppParallel/TBB.h
@@ -228,14 +228,14 @@ inline void tbbParallelFor(std::size_t begin,
                            std::size_t end, 
                            Worker& worker,
                            std::size_t grainSize = 1,
-                           int numThreads = tbb::task_arena::automatic)
+                           int numThreads = -1)
 {
    ThreadStackSizeControl control;
    
-   tbb::task_arena arena(numThreads);
    tbb::task_group group;
-   
    TBBArenaParallelForExecutor executor(group, worker, begin, end, grainSize);
+   
+   tbb::task_arena arena(numThreads);
    arena.execute(executor);
 }
 
@@ -244,14 +244,14 @@ inline void tbbParallelReduce(std::size_t begin,
                               std::size_t end, 
                               Reducer& reducer,
                               std::size_t grainSize = 1,
-                              int numThreads = tbb::task_arena::automatic)
+                              int numThreads = -1)
 {
    ThreadStackSizeControl control;
    
-   tbb::task_arena arena(numThreads);
    tbb::task_group group;
-   
    TBBArenaParallelReduceExecutor<Reducer> executor(group, reducer, begin, end, grainSize);
+   
+   tbb::task_arena arena(numThreads);
    arena.execute(executor);
 }
 

--- a/inst/skeleton/vector-sum.cpp
+++ b/inst/skeleton/vector-sum.cpp
@@ -19,37 +19,37 @@ using namespace Rcpp;
 using namespace RcppParallel;
 
 struct Sum : public Worker
-{   
+{
    // source vector
    const RVector<double> input;
-   
+
    // accumulated value
    double value;
-   
+
    // constructors
    Sum(const NumericVector input) : input(input), value(0) {}
    Sum(const Sum& sum, Split) : input(sum.input), value(0) {}
-   
+
    // accumulate just the element of the range I've been asked to
    void operator()(std::size_t begin, std::size_t end) {
       value += std::accumulate(input.begin() + begin, input.begin() + end, 0.0);
    }
-   
+
    // join my value with that of another Sum
-   void join(const Sum& rhs) { 
-      value += rhs.value; 
+   void join(const Sum& rhs) {
+      value += rhs.value;
    }
 };
 
 // [[Rcpp::export]]
 double parallelVectorSum(NumericVector x) {
-   
-   // declare the SumBody instance 
+
+   // declare the SumBody instance
    Sum sum(x);
-   
+
    // call parallel_reduce to start the work
    parallelReduce(0, x.length(), sum);
-   
+
    // return the computed sum
    return sum.value;
 }

--- a/inst/tests/cpp/innerproduct.cpp
+++ b/inst/tests/cpp/innerproduct.cpp
@@ -19,43 +19,43 @@ double innerProduct(NumericVector x, NumericVector y) {
 using namespace RcppParallel;
 
 struct InnerProduct : public Worker
-{   
+{
    // source vectors
    const RVector<double> x;
    const RVector<double> y;
-   
+
    // product that I have accumulated
    double product;
-   
+
    // constructors
-   InnerProduct(const NumericVector x, const NumericVector y) 
+   InnerProduct(const NumericVector x, const NumericVector y)
       : x(x), y(y), product(0) {}
-   InnerProduct(const InnerProduct& innerProduct, Split) 
+   InnerProduct(const InnerProduct& innerProduct, Split)
       : x(innerProduct.x), y(innerProduct.y), product(0) {}
-   
+
    // process just the elements of the range I have been asked to
    void operator()(std::size_t begin, std::size_t end) {
-      product += std::inner_product(x.begin() + begin, 
-                                    x.begin() + end, 
-                                    y.begin() + begin, 
+      product += std::inner_product(x.begin() + begin,
+                                    x.begin() + end,
+                                    y.begin() + begin,
                                     0.0);
    }
-   
+
    // join my value with that of another InnerProduct
-   void join(const InnerProduct& rhs) { 
-     product += rhs.product; 
+   void join(const InnerProduct& rhs) {
+     product += rhs.product;
    }
 };
 
 // [[Rcpp::export]]
 double parallelInnerProduct(NumericVector x, NumericVector y) {
-   
+
    // declare the InnerProduct instance that takes a pointer to the vector data
    InnerProduct innerProduct(x, y);
-   
+
    // call paralleReduce to start the work
    parallelReduce(0, x.length(), innerProduct);
-   
+
    // return the computed product
    return innerProduct.product;
 }

--- a/inst/tests/cpp/sum.cpp
+++ b/inst/tests/cpp/sum.cpp
@@ -3,7 +3,7 @@
  * @author JJ Allaire
  * @license GPL (>= 2)
  */
- 
+
 #include <Rcpp.h>
 #include <RcppParallel.h>
 
@@ -12,37 +12,42 @@ using namespace RcppParallel;
 using namespace Rcpp;
 
 struct Sum : public Worker
-{           
+{
    // source vector
    const RVector<double> input;
-   
+
    // accumulated value
    double value;
-   
+
    // constructors
    Sum(const NumericVector input) : input(input), value(0) {}
-   Sum(const Sum& sum, Split) : input(sum.input), value(0) {}
-   
+   Sum(const Sum& sum, Split) : input(sum.input), value(0) {
+      printf("ctor: invoking split constructor\n");
+   }
+
    // accumulate just the element of the range I have been asked to
    void operator()(std::size_t begin, std::size_t end) {
-      value += std::accumulate(input.begin() + begin, input.begin() + end, 0.0);
+      double extra = std::accumulate(input.begin() + begin, input.begin() + end, 0.0);
+      value += extra;
+      printf("work: added %f (value is now %f)\n", extra, value);
    }
-     
+
    // join my value with that of another Sum
-   void join(const Sum& rhs) { 
-      value += rhs.value; 
-   }             
+   void join(const Sum& rhs) {
+      value += rhs.value;
+      printf("join: added %f (value is now %f)\n", rhs.value, value);
+   }
 };
 
 // [[Rcpp::export]]
 double parallelVectorSum(NumericVector x) {
-   
-   // declare the SumBody instance 
+
+   // declare the SumBody instance
    Sum sum(x);
-   
+
    // call parallel_reduce to start the work
    parallelReduce(0, x.length(), sum);
-   
+
    // return the computed sum
    return sum.value;
 }

--- a/src/tbb.cpp
+++ b/src/tbb.cpp
@@ -1,4 +1,6 @@
 
+#if RCPP_PARALLEL_USE_TBB
+
 #include <RcppParallel/Common.h>
 #include <RcppParallel/TBB.h>
 
@@ -6,9 +8,22 @@ namespace RcppParallel {
 
 tbb::global_control* s_globalControl = nullptr;
 
+// TBB Tools ----
+
+struct TBBWorker
+{
+   explicit TBBWorker(Worker& worker) : worker_(worker) {}
+
+   void operator()(const tbb::blocked_range<size_t>& r) const {
+      worker_(r.begin(), r.end());
+   }
+
+private:
+   Worker& worker_;
+};
+
 ThreadStackSizeControl::ThreadStackSizeControl()
 {
-#ifdef RCPP_PARALLEL_USE_TBB
    int stackSize = resolveValue("RCPP_PARALLEL_STACK_SIZE", 0, 0);
    if (stackSize > 0)
    {
@@ -17,24 +32,24 @@ ThreadStackSizeControl::ThreadStackSizeControl()
          stackSize
       );
    }
-#endif
 }
 
 ThreadStackSizeControl::~ThreadStackSizeControl()
 {
-#ifdef RCPP_PARALLEL_USE_TBB
    if (s_globalControl != nullptr)
    {
       delete s_globalControl;
       s_globalControl = nullptr;
    }
-#endif
 }
+
+
+// TBB Parallel For ----
 
 class TBBParallelForExecutor
 {
 public:
-   
+
    TBBParallelForExecutor(Worker& worker,
                           std::size_t begin,
                           std::size_t end,
@@ -45,7 +60,7 @@ public:
         grainSize_(grainSize)
    {
    }
-   
+
    void operator()() const
    {
       TBBWorker tbbWorker(worker_);
@@ -54,7 +69,7 @@ public:
          tbbWorker
       );
    }
-   
+
 private:
    Worker& worker_;
    std::size_t begin_;
@@ -65,7 +80,7 @@ private:
 class TBBArenaParallelForExecutor
 {
 public:
-   
+
    TBBArenaParallelForExecutor(tbb::task_group& group,
                                Worker& worker,
                                std::size_t begin,
@@ -78,15 +93,15 @@ public:
         grainSize_(grainSize)
    {
    }
-   
+
    void operator()() const
    {
       TBBParallelForExecutor executor(worker_, begin_, end_, grainSize_);
       group_.run_and_wait(executor);
    }
-   
+
 private:
-   
+
    tbb::task_group& group_;
    Worker& worker_;
    std::size_t begin_;
@@ -101,12 +116,125 @@ void tbbParallelFor(std::size_t begin,
                     int numThreads)
 {
    ThreadStackSizeControl control;
-   
+
    tbb::task_group group;
    TBBArenaParallelForExecutor executor(group, worker, begin, end, grainSize);
-   
+
+   tbb::task_arena arena(numThreads);
+   arena.execute(executor);
+}
+
+
+// TBB Parallel Reduce ----
+
+struct TBBReducer
+{
+   explicit TBBReducer(ReducerWrapper& reducer)
+      : pSplitReducer_(NULL), reducer_(reducer)
+   {
+   }
+
+   TBBReducer(TBBReducer& tbbReducer, tbb::split)
+      : pSplitReducer_(new ReducerWrapper(tbbReducer.reducer_, RcppParallel::Split())),
+        reducer_(*pSplitReducer_)
+   {
+   }
+
+   virtual ~TBBReducer() { delete pSplitReducer_; }
+
+   void operator()(const tbb::blocked_range<size_t>& r)
+   {
+      reducer_(r.begin(), r.end());
+   }
+
+   void join(const TBBReducer& tbbReducer)
+   {
+      reducer_.join(tbbReducer.reducer_);
+   }
+
+private:
+   ReducerWrapper* pSplitReducer_;
+   ReducerWrapper& reducer_;
+};
+
+class TBBParallelReduceExecutor
+{
+public:
+
+   TBBParallelReduceExecutor(ReducerWrapper& reducer,
+                             std::size_t begin,
+                             std::size_t end,
+                             std::size_t grainSize)
+      : reducer_(reducer),
+        begin_(begin),
+        end_(end),
+        grainSize_(grainSize)
+   {
+   }
+
+   void operator()() const
+   {
+      TBBReducer tbbReducer(reducer_);
+      tbb::parallel_reduce(
+         tbb::blocked_range<std::size_t>(begin_, end_, grainSize_),
+         tbbReducer
+      );
+   }
+
+private:
+   ReducerWrapper& reducer_;
+   std::size_t begin_;
+   std::size_t end_;
+   std::size_t grainSize_;
+};
+
+class TBBArenaParallelReduceExecutor
+{
+public:
+
+   TBBArenaParallelReduceExecutor(tbb::task_group& group,
+                                  ReducerWrapper& reducer,
+                                  std::size_t begin,
+                                  std::size_t end,
+                                  std::size_t grainSize)
+      : group_(group),
+        reducer_(reducer),
+        begin_(begin),
+        end_(end),
+        grainSize_(grainSize)
+   {
+   }
+
+   void operator()() const
+   {
+      TBBParallelReduceExecutor executor(reducer_, begin_, end_, grainSize_);
+      group_.run_and_wait(executor);
+   }
+
+private:
+
+   tbb::task_group& group_;
+   ReducerWrapper& reducer_;
+   std::size_t begin_;
+   std::size_t end_;
+   std::size_t grainSize_;
+};
+
+void tbbParallelReduceImpl(std::size_t begin,
+                           std::size_t end,
+                           ReducerWrapper& reducer,
+                           std::size_t grainSize,
+                           int numThreads)
+{
+   ThreadStackSizeControl control;
+
+   tbb::task_group group;
+   TBBArenaParallelReduceExecutor executor(group, reducer, begin, end, grainSize);
+
    tbb::task_arena arena(numThreads);
    arena.execute(executor);
 }
 
 } // end namespace RcppParallel
+
+#endif /* RCPP_PARALLEL_USE_TBB */

--- a/src/tbb.cpp
+++ b/src/tbb.cpp
@@ -1,0 +1,42 @@
+
+
+#include <RcppParallel/Common.h>
+
+#ifndef TBB_PREVIEW_GLOBAL_CONTROL
+# define TBB_PREVIEW_GLOBAL_CONTROL 1
+#endif
+
+#include <tbb/tbb.h>
+#include <tbb/global_control.h>
+#include <tbb/scalable_allocator.h>
+
+namespace RcppParallel {
+
+tbb::global_control* s_globalControl = nullptr;
+
+ThreadStackSizeControl::ThreadStackSizeControl()
+{
+#ifdef RCPP_PARALLEL_USE_TBB
+   int stackSize = resolveValue("RCPP_PARALLEL_STACK_SIZE", 0, 0);
+   if (stackSize > 0)
+   {
+      s_globalControl = new tbb::global_control(
+         tbb::global_control::thread_stack_size,
+         stackSize
+      );
+   }
+#endif
+}
+
+ThreadStackSizeControl::~ThreadStackSizeControl()
+{
+#ifdef RCPP_PARALLEL_USE_TBB
+   if (s_globalControl != nullptr)
+   {
+      delete s_globalControl;
+      s_globalControl = nullptr;
+   }
+#endif
+}
+
+} // end namespace RcppParallel

--- a/src/tbb.cpp
+++ b/src/tbb.cpp
@@ -1,14 +1,6 @@
 
-
 #include <RcppParallel/Common.h>
-
-#ifndef TBB_PREVIEW_GLOBAL_CONTROL
-# define TBB_PREVIEW_GLOBAL_CONTROL 1
-#endif
-
-#include <tbb/tbb.h>
-#include <tbb/global_control.h>
-#include <tbb/scalable_allocator.h>
+#include <RcppParallel/TBB.h>
 
 namespace RcppParallel {
 
@@ -37,6 +29,84 @@ ThreadStackSizeControl::~ThreadStackSizeControl()
       s_globalControl = nullptr;
    }
 #endif
+}
+
+class TBBParallelForExecutor
+{
+public:
+   
+   TBBParallelForExecutor(Worker& worker,
+                          std::size_t begin,
+                          std::size_t end,
+                          std::size_t grainSize)
+      : worker_(worker),
+        begin_(begin),
+        end_(end),
+        grainSize_(grainSize)
+   {
+   }
+   
+   void operator()() const
+   {
+      TBBWorker tbbWorker(worker_);
+      tbb::parallel_for(
+         tbb::blocked_range<std::size_t>(begin_, end_, grainSize_),
+         tbbWorker
+      );
+   }
+   
+private:
+   Worker& worker_;
+   std::size_t begin_;
+   std::size_t end_;
+   std::size_t grainSize_;
+};
+
+class TBBArenaParallelForExecutor
+{
+public:
+   
+   TBBArenaParallelForExecutor(tbb::task_group& group,
+                               Worker& worker,
+                               std::size_t begin,
+                               std::size_t end,
+                               std::size_t grainSize)
+      : group_(group),
+        worker_(worker),
+        begin_(begin),
+        end_(end),
+        grainSize_(grainSize)
+   {
+   }
+   
+   void operator()() const
+   {
+      TBBParallelForExecutor executor(worker_, begin_, end_, grainSize_);
+      group_.run_and_wait(executor);
+   }
+   
+private:
+   
+   tbb::task_group& group_;
+   Worker& worker_;
+   std::size_t begin_;
+   std::size_t end_;
+   std::size_t grainSize_;
+};
+
+void tbbParallelFor(std::size_t begin,
+                    std::size_t end,
+                    Worker& worker,
+                    std::size_t grainSize,
+                    int numThreads)
+{
+   ThreadStackSizeControl control;
+   
+   tbb::task_group group;
+   TBBArenaParallelForExecutor executor(group, worker, begin, end, grainSize);
+   
+   tbb::task_arena arena(numThreads);
+   arena.execute(executor);
 }
 
 } // end namespace RcppParallel


### PR DESCRIPTION
This PR sets the ground-work for an RcppParallel 5.1.10 release, whose main goals are to remove the accidental direct dependency on TBB that packages get when using RcppParallel's utilities. Using gaston from CRAN as an example:

```sh
kevin@kevinushey-NPCV:~/Library/R/arm64/4.4/library
$ nm gaston/libs/gaston.so | grep tbb | grep U | c++filt
                 U tbb::interface5::internal::task_base::destroy(tbb::task&)
                 U tbb::interface7::internal::task_arena_base::internal_terminate()
                 U tbb::interface7::internal::task_arena_base::internal_initialize()
                 U tbb::interface9::global_control::internal_create()
                 U tbb::interface9::global_control::internal_destroy()
                 U tbb::task_group_context::cancel_group_execution()
                 U tbb::task_group_context::register_pending_exception()
                 U tbb::task_group_context::init()
                 U tbb::task_group_context::reset()
                 U tbb::task_group_context::~task_group_context()
                 U tbb::task::note_affinity(unsigned short)
                 U tbb::internal::throw_exception_v4(tbb::internal::exception_id)
                 U tbb::internal::get_initial_auto_partitioner_divisor()
                 U tbb::interface7::internal::task_arena_base::internal_execute(tbb::interface7::internal::delegate_base&) const
                 U tbb::task_group_context::is_group_execution_cancelled() const
                 U tbb::internal::allocate_child_proxy::allocate(unsigned long) const
                 U tbb::internal::allocate_continuation_proxy::allocate(unsigned long) const
                 U tbb::internal::allocate_root_with_context_proxy::free(tbb::task&) const
                 U tbb::internal::allocate_root_with_context_proxy::allocate(unsigned long) const
                 U typeinfo for tbb::task
```

What this means is that any attempts to RcppParallel which change tbb internals will break packages like gaston, since those symbols may no longer be available (e.g. because they've moved to different namespaces, or APIs have changed altogether).

This PR resolves the issue by hiding the implementation details for parallelFor and parallelReduce within RcppParallel. This was harder than I expected because we allowed classes of the form:

```cpp
struct InnerProduct : public RcppParallel::Worker {
  void join(const InnerProduct& rhs) { ... }
};
```

And so, we have no knowledge of the actual user-defined class or its type from within the RcppParallel worker. Hence, we need to take the template type passed to `tbbParallelReduce()`, use that to construct a whole bunch of type-erased methods within a non-template class, and then pass that blob down. Gross.

I'm hoping that, sometime after R 4.5.0 is released, we'll be able to delete this "glue" and have a more sane interface, but we'll see.