### PR TITLE
Fix compilation under clang-19 aarch64

### DIFF
--- a/src/tbb-compat/tbb-compat.cpp
+++ b/src/tbb-compat/tbb-compat.cpp
@@ -40,7 +40,7 @@ public:
    /** For local observers the method can be used only when the current thread
     has the task scheduler initialized or is attached to an arena.
     Repeated calls with the same state are no-ops. **/
-   void __TBB_EXPORTED_METHOD observe( bool state=true );
+   void DLL_EXPORT __TBB_EXPORTED_METHOD observe( bool state=true );
    
    //! Returns true if observation is enabled, false otherwise.
    bool is_observing() const {return my_proxy!=NULL;}


### PR DESCRIPTION
The development version is failing to compile under the rtools45 pre-release for Windows Arm because one of the methods in the `tbb-compat` stub is missing an attribute from one the declarations:

```
Installing package into 'C:/Users/andrew/AppData/Local/R/aarch64-library/4.6'
(as 'lib' is unspecified)
* installing *source* package 'RcppParallel' ...
** this is package 'RcppParallel' version '5.1.10.9000'
** using staged installation
** preparing to configure package 'RcppParallel' ...
*** configured file: 'R/tbb-autodetected.R.in' => 'R/tbb-autodetected.R'
*** configured file: 'src/Makevars.in' => 'src/Makevars'
** finished configure for package 'RcppParallel'
** libs
using C++ compiler: 'clang version 19.1.7'
installing via 'install.libs.R' to C:/Users/andrew/AppData/Local/R/aarch64-library/4.6/00LOCK-RcppParallel/00new/RcppParallel
** creating tbb stub library
using C++ compiler: 'clang version 19.1.7'
clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG -I../inst/include -I"C:/rtools45-aarch64/aarch64-w64-mingw32.static.posix/include"    -I"/aarch64-w64-mingw32.static.posix/include"   -DRCPP_PARALLEL_USE_TBB=1   -O2 -Wall      -c tbb-compat/tbb-compat.cpp -o tbb-compat/tbb-compat.o
tbb-compat/tbb-compat.cpp:137:54: error: redeclaration of 'tbb::internal::task_scheduler_observer_v3::observe' cannot add 'dllexport' attribute
  137 | void __TBB_EXPORTED_FUNC task_scheduler_observer_v3::observe( bool enable ) {
      |                                                      ^
tbb-compat/tbb-compat.cpp:43:31: note: previous declaration is here
   43 |    void __TBB_EXPORTED_METHOD observe( bool state=true );
      |                               ^
1 error generated.
make: *** [C:/PROGRA~1/R-AARC~1/R-devel/etc/Makeconf:296: tbb-compat/tbb-compat.o] Error 1
Error in .install.libs(tbbLib) : error building tbb stub library
* removing 'C:/Users/andrew/AppData/Local/R/aarch64-library/4.6/RcppParallel'
* restoring previous 'C:/Users/andrew/AppData/Local/R/aarch64-library/4.6/RcppParallel'
Warning message:
In install.packages(getwd(), type = "source", repos = NULL) :
```

This errors since [clang has different handling of attributes in this case](https://github.com/llvm/llvm-project/issues/55329), and attribute needs to be present in both declarations