### PR TITLE
Fix tbb-compat linking after rename

### DIFF
--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -74,10 +74,10 @@
       tbbDll <- file.path(tbbDest, "tbb.dll")
       if (!file.exists(tbbDll)) {
          writeLines("** creating tbb stub library")
-         status <- system("R CMD SHLIB tbb-compat/tbb-compat.cpp")
+         status <- system("R CMD SHLIB -o tbb-compat/tbb.dll tbb-compat/tbb-compat.cpp")
          if (status != 0)
             stop("error building tbb stub library")
-         file.rename("tbb-compat/tbb-compat.dll", file.path(tbbDest, "tbb.dll"))
+         file.copy("tbb-compat/tbb.dll", file.path(tbbDest, "tbb.dll"))
       }
    }
    


### PR DESCRIPTION
Unsure if it's because of clang or windows arm64, but `rstan` models compiled against the current github `RcppParallel` fail at runtime with an error that `tbb-compat.dll` is not found - even though the DLL has been renamed to `tbb.dll` before being linked.

I believe this is because `R CMD SHLIB` generates a `.def` file when linking with the name of the DLL. Explicitly setting the output name to `tbb.dll` when calling `R CMD SHLIB` resolves the later runtime errors for me