### PR TITLE
Remove obsolete flag for WINARM64, fix TBB library lookup on Windows

### DIFF
--- a/R/tbb.R
+++ b/R/tbb.R
@@ -24,7 +24,7 @@ tbbLibraryPath <- function(name = NULL) {
    # form library names
    tbbLibNames <- list(
       "Darwin"  = paste0("lib", name, ".dylib"),
-      "Windows" = paste0(       name, ".dll"),
+      "Windows" = paste0("lib", name, c("12", ""), ".a"),
       "SunOS"   = paste0("lib", name, ".so"),
       "Linux"   = paste0("lib", name, c(".so.2", ".so"))
    )

--- a/R/tbb.R
+++ b/R/tbb.R
@@ -58,14 +58,6 @@ tbbCxxFlags <- function() {
       return("-DRCPP_PARALLEL_USE_TBB=0")
    
    flags <- c("-DRCPP_PARALLEL_USE_TBB=1")
-   
-   # TBB does not have assembly code for Windows ARM64
-   # so we need to use compiler builtins
-   if (TBB_ENABLED && is_windows()) {
-      if (R.version$arch == "aarch64") {
-         flags <- c(flags, "-DTBB_USE_GCC_BUILTINS")
-      }
-   }
 
    # if TBB_INC is set, apply those library paths
    tbbInc <- Sys.getenv("TBB_INC", unset = TBB_INC)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,7 +11,10 @@
 .tbbMallocProxyDllInfo <- NULL
 
 loadTbbLibrary <- function(name) {
-   
+   # TBB is statically linked on Windows
+   if (is_windows()) {
+      return(NULL)
+   }
    path <- tbbLibraryPath(name)
    if (is.null(path))
       return(NULL)

--- a/inst/include/RcppParallel.h
+++ b/inst/include/RcppParallel.h
@@ -18,9 +18,6 @@
 #endif
 
 #if RCPP_PARALLEL_USE_TBB
-# if defined(WINNT) && defined(__aarch64__) && !defined(TBB_USE_GCC_BUILTINS)
-#  define TBB_USE_GCC_BUILTINS 1
-# endif
 # include "RcppParallel/TBB.h"
 #endif
 


### PR DESCRIPTION
Now that `RcppParallel` is using a newer version of the TBB, the `TBB_USE_GCC_BUILTINS` flag is irrelevant on Windows arm64

The `tbbLibraryPath()` function was also looking for `.dll` files on windows, so wasn't returning the static lib