### PR TITLE
fix bundled tbb build issues on macos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # RcppParallel (development version)
 
+* When building the bundled copy of oneTBB, RcppParallel no longer searches
+  for hwloc, and so no longer tries to build the optional 'tbbbind' library.
+  This fixes build failures on machines where a static hwloc library is
+  discoverable via pkg-config, as on the CRAN macOS machines.
+
+* On macOS, the bundled copy of oneTBB is now built with
+  `__TBB_RESUMABLE_TASKS_USE_THREADS`, avoiding use of the deprecated
+  ucontext APIs (`getcontext`, `swapcontext`, `makecontext`).
+
 
 # RcppParallel 6.0.0
 

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -116,12 +116,23 @@ useBundledTbb <- function() {
    prependFlags("CPPFLAGS", "CFLAGS")
    prependFlags("CPPFLAGS", "CXXFLAGS")
 
+   # the ucontext APIs (getcontext, swapcontext, ...) are deprecated on macOS,
+   # so use the threads-based coroutine implementation for resumable tasks
+   if (Sys.info()[["sysname"]] == "Darwin") {
+      flags <- c(Sys.getenv("CXXFLAGS"), "-D__TBB_RESUMABLE_TASKS_USE_THREADS=1")
+      setenv("CXXFLAGS", flags[nzchar(flags)])
+   }
+
    cmakeFlags <- c(
       forwardEnvVar("CC", "CMAKE_C_COMPILER"),
       forwardEnvVar("CXX", "CMAKE_CXX_COMPILER"),
       forwardEnvVar("CFLAGS", "CMAKE_C_FLAGS"),
       forwardEnvVar("CXXFLAGS", "CMAKE_CXX_FLAGS"),
       forwardEnvVar("CMAKE_BUILD_TYPE", "CMAKE_BUILD_TYPE"),
+      # tbbbind requires hwloc, and hwloc's pkg-config file doesn't advertise
+      # the macOS frameworks needed when linking it statically; RcppParallel
+      # doesn't use TBB's NUMA APIs, so skip tbbbind altogether
+      "-DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=1",
       "-DTBB_TEST=0",
       "-DTBB_EXAMPLES=0",
       "-DTBB_STRICT=0",


### PR DESCRIPTION
## Summary

Fixes the RcppParallel build failure on the CRAN macOS machines
(https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/RcppParallel-00install.html),
and resolves the `getcontext` / `swapcontext` / `makecontext` deprecation warnings there.

### tbbbind link failure

oneTBB's CMake automatically searches for hwloc via pkg-config and, if found, builds the
optional `tbbbind` NUMA-support library. The CRAN macOS machines now have a static-only
hwloc discoverable via pkg-config, but `pkg_search_module()` requests the shared-link flags,
which omit the `Libs.private` frameworks (CoreFoundation, IOKit, OpenCL) required when
linking hwloc statically. The `tbbbind_2_5` link then fails with undefined symbols.

RcppParallel doesn't use TBB's NUMA APIs (and `libtbb` only ever loads tbbbind lazily via
`dlopen`, falling back gracefully when absent), so we now pass
`-DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=1` and skip tbbbind entirely. This also makes the
build deterministic regardless of what's installed on the build machine, and avoids shipping
a `libtbbbind` bound to a build-machine hwloc that wouldn't exist on user machines.

### ucontext deprecation warnings

The ucontext APIs used by oneTBB's coroutine implementation for resumable tasks have been
deprecated on macOS since 10.6. We now build the bundled oneTBB with
`-D__TBB_RESUMABLE_TASKS_USE_THREADS=1` on macOS, selecting oneTBB's threads-based
coroutine implementation (the same code path upstream uses under sanitizers), so the
deprecated APIs are no longer referenced at all.

## Testing

- Fresh `R CMD INSTALL --preclean` on macOS arm64 succeeds; CMake logs confirm no tbbbind
  targets are created and the define is applied to all TBB compile lines.
- `nm -u libtbb.dylib` shows no `_getcontext` / `_swapcontext` / `_makecontext` references
  (previously present).
- Installed libs are exactly `libtbb.dylib`, `libtbbmalloc.dylib`, `libtbbmalloc_proxy.dylib`;
  package loads and `setThreadOptions()` / `defaultNumThreads()` work.