### PR TITLE
fix lookup path for tbb stub library on windows

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -20,7 +20,12 @@ loadTbbLibrary <- function(name) {
    # DLL search path.
    if (is_windows()) {
 
-      path <- file.path(tbbRoot(), paste0(name, ".dll"))
+      # NOTE: resolve against the package's own library directory, where
+      # install.libs.R places the stub; tbbRoot() would prefer TBB_LIB,
+      # which on Windows points at Rtools and holds only static libraries
+      arch <- .Platform$r_arch
+      parts <- c("lib", if (nzchar(arch)) arch, paste0(name, ".dll"))
+      path <- system.file(paste(parts, collapse = "/"), package = "RcppParallel")
       if (!file.exists(path))
          return(NULL)
 


### PR DESCRIPTION
Follow-up to #249: the stub loader resolved `tbb.dll` via `tbbRoot()`, which prefers `TBB_LIB` when set. On Windows, configure always sets `TBB_LIB` to the Rtools library directory (the source of the static TBB link), which contains no DLLs -- so the lookup silently failed and the stub was never loaded. Confirmed on a real Windows machine: after loading a patched RcppParallel, `getLoadedDLLs()` showed no `tbb` entry.

Resolve against the package's own `lib/x64` directory instead, which is where `install.libs.R` places the stub.