### PR TITLE
add systemFile() helper for arch-aware package paths

### DIFF
--- a/R/tbb.R
+++ b/R/tbb.R
@@ -41,10 +41,8 @@ tbbLibraryPath <- function(name = NULL) {
       tbbName <- file.path(tbbRoot, libName)
       if (file.exists(tbbName))
          return(tbbName)
-      
-      arch <- if (nzchar(.Platform$r_arch)) .Platform$r_arch
-      suffix <- paste(c("lib", arch, libName), collapse = "/")
-      tbbName <- system.file(suffix, package = "RcppParallel")
+
+      tbbName <- systemFile("lib", libName)
       if (file.exists(tbbName))
          return(tbbName)
       
@@ -90,10 +88,8 @@ tbbLdFlags <- function() {
    # on Windows, we statically link to oneTBB
    if (is_windows()) {
       
-      libPath <- system.file("libs", package = "RcppParallel")
-      if (nzchar(.Platform$r_arch))
-         libPath <- file.path(libPath, .Platform$r_arch)
-      
+      libPath <- systemFile("libs")
+
       ldFlags <- sprintf("-L%s -lRcppParallel", asBuildPath(libPath))
       return(ldFlags)
       
@@ -127,9 +123,6 @@ tbbRoot <- function() {
    if (nzchar(TBB_LIB))
       return(TBB_LIB)
 
-   rArch <- .Platform$r_arch
-   parts <- c("lib", if (nzchar(rArch)) rArch)
-   libDir <- paste(parts, collapse = "/")
-   system.file(libDir, package = "RcppParallel")
+   systemFile("lib")
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,12 @@
 
+# like system.file(), but injects the architecture-specific subdirectory
+# used on Windows when set; e.g. systemFile("lib") resolves 'lib/x64'
+systemFile <- function(dir, name = NULL) {
+   arch <- .Platform$r_arch
+   parts <- c(dir, if (nzchar(arch)) arch, name)
+   system.file(paste(parts, collapse = "/"), package = "RcppParallel")
+}
+
 # generate paths consumable by the compilers and linkers
 # in particular, on Windows and Solaris, this means the path _cannot_ be quoted !!
 asBuildPath <- function(path) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,9 +23,7 @@ loadTbbLibrary <- function(name) {
       # NOTE: resolve against the package's own library directory, where
       # install.libs.R places the stub; tbbRoot() would prefer TBB_LIB,
       # which on Windows points at Rtools and holds only static libraries
-      arch <- .Platform$r_arch
-      parts <- c("lib", if (nzchar(arch)) arch, paste0(name, ".dll"))
-      path <- system.file(paste(parts, collapse = "/"), package = "RcppParallel")
+      path <- systemFile("lib", paste0(name, ".dll"))
       if (!file.exists(path))
          return(NULL)
 


### PR DESCRIPTION
Follow-up to #250. Four places constructed paths within the installed package while handling the architecture-specific subdirectory used on Windows (`lib/x64` vs `lib`): the stub loader in `zzz.R`, and `tbbLibraryPath()` / `tbbLdFlags()` / `tbbRoot()` in `tbb.R`. Consolidate them into a single `systemFile()` helper in `utils.R`, next to `asBuildPath()`.

No behavior change intended; `systemFile("lib", "tbb.dll")` resolves e.g. `lib/x64/tbb.dll` via `system.file()`, returning "" when absent, matching the previous call sites.