### PR TITLE
rename systemFile() to archSystemFile()

### DIFF
--- a/R/tbb.R
+++ b/R/tbb.R
@@ -42,7 +42,7 @@ tbbLibraryPath <- function(name = NULL) {
       if (file.exists(tbbName))
          return(tbbName)
 
-      tbbName <- systemFile("lib", libName)
+      tbbName <- archSystemFile("lib", libName)
       if (file.exists(tbbName))
          return(tbbName)
       
@@ -88,7 +88,7 @@ tbbLdFlags <- function() {
    # on Windows, we statically link to oneTBB
    if (is_windows()) {
       
-      libPath <- systemFile("libs")
+      libPath <- archSystemFile("libs")
 
       ldFlags <- sprintf("-L%s -lRcppParallel", asBuildPath(libPath))
       return(ldFlags)
@@ -123,6 +123,6 @@ tbbRoot <- function() {
    if (nzchar(TBB_LIB))
       return(TBB_LIB)
 
-   systemFile("lib")
+   archSystemFile("lib")
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 
 # like system.file(), but injects the architecture-specific subdirectory
-# used on Windows when set; e.g. systemFile("lib") resolves 'lib/x64'
-systemFile <- function(dir, name = NULL) {
+# used on Windows when set; e.g. archSystemFile("lib") resolves 'lib/x64'
+archSystemFile <- function(dir, name = NULL) {
    arch <- .Platform$r_arch
    parts <- c(dir, if (nzchar(arch)) arch, name)
    system.file(paste(parts, collapse = "/"), package = "RcppParallel")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,7 @@ loadTbbLibrary <- function(name) {
       # NOTE: resolve against the package's own library directory, where
       # install.libs.R places the stub; tbbRoot() would prefer TBB_LIB,
       # which on Windows points at Rtools and holds only static libraries
-      path <- systemFile("lib", paste0(name, ".dll"))
+      path <- archSystemFile("lib", paste0(name, ".dll"))
       if (!file.exists(path))
          return(NULL)
 


### PR DESCRIPTION
Follow-up to #251: `systemFile` didn't convey how the helper differs from `system.file()` -- the distinguishing behavior is injecting the architecture-specific subdirectory (`lib/x64` vs `lib`). Pure rename, no behavior change.