### PR TITLE
apply cpuid guard to tbb headers copied at install time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@
   RcppParallel 6.0.0, such packages would fail to load with "LoadLibrary
   failure: The specified module could not be found".
 
-* The bundled oneTBB headers now guard against GCC's `<cpuid.h>` being
+* The TBB headers installed with RcppParallel (whether from Rtools or from
+  the bundled copy of oneTBB) now guard against GCC's `<cpuid.h>` being
   included before `<intrin.h>` on Windows (mingw). Previously, translation
   units including `<cpuid.h>` before any TBB header would fail to compile,
   as the `__cpuid` macro from `<cpuid.h>` conflicts with the `__cpuid()`

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -88,6 +88,7 @@
 }
 
 useTbbPreamble <- function(tbbInc) {
+
    dir.create("../inst/include", recursive = TRUE, showWarnings = FALSE)
    for (suffix in c("oneapi", "serial", "tbb")) {
       tbbPath <- file.path(tbbInc, suffix)
@@ -95,6 +96,45 @@ useTbbPreamble <- function(tbbInc) {
          file.copy(tbbPath, "../inst/include", recursive = TRUE)
       }
    }
+
+   patchTbbMachineHeader("../inst/include/oneapi/tbb/detail/_machine.h")
+
+}
+
+# Guard the '#include <intrin.h>' in TBB's _machine.h against GCC's
+# <cpuid.h> macro on mingw. The headers we ship may come from Rtools
+# rather than from the bundled copy of oneTBB, so the guard must be
+# applied to the copied headers, not just the bundled sources.
+patchTbbMachineHeader <- function(path) {
+
+   if (!file.exists(path))
+      return()
+
+   contents <- readLines(path)
+   if (any(grepl("push_macro", contents, fixed = TRUE)))
+      return()
+
+   index <- which(contents == "#include <intrin.h>")
+   if (length(index) != 1L)
+      return()
+
+   replacement <- c(
+      "// GCC's <cpuid.h> defines a function-like '__cpuid' macro that mangles the",
+      "// __cpuid() declarations in mingw's <intrin.h>. Hide the macro while",
+      "// including <intrin.h> so the two headers can coexist in any order.",
+      "#if defined(__MINGW32__) && defined(__cpuid)",
+      "#pragma push_macro(\"__cpuid\")",
+      "#undef __cpuid",
+      "#include <intrin.h>",
+      "#pragma pop_macro(\"__cpuid\")",
+      "#else",
+      "#include <intrin.h>",
+      "#endif"
+   )
+
+   contents <- append(contents[-index], replacement, after = index - 1L)
+   writeLines(contents, path)
+
 }
 
 useSystemTbb <- function(tbbLib, tbbInc) {


### PR DESCRIPTION
Follow-up to #248, which turned out to be incomplete: on Windows, RcppParallel ships the TBB headers provided by **Rtools**, not the bundled oneTBB copy -- `useTbbPreamble()` copies them from `TBB_INC` at build time. So the `__cpuid` guard patched into the bundled sources never reached installed packages on Windows, and the `cpuid.h`/`intrin.h` include-order conflict persisted. Confirmed on a real Rtools45 setup: the sourceCpp repro (`#include <cpuid.h>` before `<tbb/parallel_sort.h>`) still failed against a patched build, with the installed `_machine.h` showing the unpatched line.

This applies the same guard by post-processing the copied `_machine.h` in `useTbbPreamble()`, covering both the Rtools and bundled header sources. The patch function is idempotent (skips if `push_macro` already present) and bails unless the header contains exactly one bare `#include <intrin.h>` line, so unexpected header layouts are left untouched.

Tested: patching a pristine v6.0.0 `_machine.h` produces output identical (modulo blank lines) to the source-patched bundled header; re-running is a no-op; files without the expected include are left unmodified. `_flow_graph_trace_impl.h` is the only other TBB header including `<intrin.h>`, and only under `_MSC_VER`, so `_machine.h` remains the single mingw chokepoint.