### PR TITLE
use configure-detected TBB_LIB during install.libs

### DIFF
--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -319,6 +319,15 @@ if (identical(args, "build")) {
       useBundledTbb()
    }
 } else {
+
+   # prefer the configure-detected TBB_LIB when the environment variable
+   # is unset; otherwise, e.g. on Windows (where configure detects the
+   # Rtools copy of TBB), we'd wrongly take the bundled-TBB branch below,
+   # and ship any stale artifacts present in tbb/build/lib_release
    source("../R/tbb-autodetected.R")
+   if (!nzchar(tbbLib))
+      tbbLib <- TBB_LIB
+
    .install.libs(tbbLib)
+
 }


### PR DESCRIPTION
At the install-libs phase, `TBB_LIB` was read only from the environment, which is typically unset there (configure communicates it to the build via make variables, not the environment). Consequences:

- **Windows**: `.install.libs()` wrongly took the bundled-TBB branch and copied whatever matched `^tbb.*\.dll$` out of `src/tbb/build/lib_release`. In a long-lived working tree, that directory can hold TBB DLLs from the RcppParallel 5.x make-based build (confirmed in the wild: a 5.1.x-era `tbb.dll`/`tbbmalloc.dll`/`tbbmalloc_proxy.dll` set was silently shipped, and the presence of the stale `tbb.dll` also suppressed the tbb stub build). Fresh trees were unaffected (empty `lib_release` -> stub built), which is why CRAN/r-universe binaries were correct.
- **Linux/macOS with system TBB**: the same misdispatch meant no TBB libraries were copied/symlinked into the package at all (loading still worked via the `TBB_LIB` fallback in `tbbLibraryPath()`).

Fall back to the configure-detected value from `R/tbb-autodetected.R` (already sourced right there, previously unused) when the environment variable is unset. Windows installs now deterministically take the system-TBB branch (copy nothing from Rtools, build the stub), making stale `lib_release` artifacts inert.

Note: `tools/config/cleanup.R` deliberately leaves `src/tbb/build` in place (commented-out unlink), presumably to keep incremental dev builds fast -- left untouched here since this fix makes the stale artifacts harmless.