### PR TITLE
clean stale tbb build artifacts before shipping libraries

### DIFF
--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -236,6 +236,10 @@ useBundledTbb <- function() {
       full.names = TRUE
    )
 
+   # clear any artifacts from prior builds, so that we only ship
+   # the libraries produced by the build above
+   unlink("tbb/build/lib_release", recursive = TRUE)
+
    dir.create("tbb/build/lib_release", recursive = TRUE, showWarnings = FALSE)
    file.copy(tbbFiles, "tbb/build/lib_release", overwrite = TRUE)
    unlink("tbb/build-tbb", recursive = TRUE)

--- a/tools/config/cleanup.R
+++ b/tools/config/cleanup.R
@@ -2,8 +2,11 @@
 # Clean up files generated during configuration here.
 # Use 'remove_file()' to remove files generated during configuration.
 
-# unlink("src/tbb/build", recursive = TRUE)
-# unlink("src/tbb/build-tbb", recursive = TRUE)
+# NOTE: stale artifacts in src/tbb/build can otherwise be swept into the
+# installed package; the bundled TBB is rebuilt from scratch on each
+# install, so nothing is lost by removing these
+unlink("src/tbb/build", recursive = TRUE)
+unlink("src/tbb/build-tbb", recursive = TRUE)
 unlink("inst/lib",  recursive = TRUE)
 unlink("inst/libs", recursive = TRUE)
 unlink("inst/include/index.html", recursive = TRUE)


### PR DESCRIPTION
Companion to #254. Long-lived working trees can carry TBB libraries in `src/tbb/build/lib_release` from prior builds -- including from the pre-6.0 make-based build system, whose Windows DLLs (`tbb.dll`, `tbbmalloc.dll`, `tbbmalloc_proxy.dll`) were confirmed being swept into installed packages, masking the tbb stub library. #254 makes the Windows dispatch immune; this adds the actual cleanup:

- `useBundledTbb()` clears `lib_release` before repopulating it, so installs ship exactly what the current build produced (also prevents cross-version leftovers on Linux/macOS, e.g. an old `libtbb.so.2` alongside a new `libtbb.so.12`, both matching the copy pattern).
- Enable the previously commented-out removal of `src/tbb/build` in `cleanup.R` (runs on `--preclean`/`--clean`/`R CMD build`). Since the cmake migration, the bundled TBB rebuilds from scratch on every install (`build-tbb` is deleted after each build), so these artifacts were never reused and removing them costs nothing.

Tarballs were already safe: `.Rbuildignore` excludes `^src/tbb/build$`.