### PR TITLE
fix installation on windows without an rtools tbb

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # RcppParallel (development version)
 
+* Fixed installation on Windows systems whose Rtools does not provide TBB
+  (R < 4.2.0): configure no longer requires cmake there, and the tbb stub
+  library is no longer built when the TBB backend is disabled.
+
 * RcppParallel now reports which TBB headers and libraries are installed
   with the package, and from where, during package installation. In
   addition, setting the `VERBOSE` environment variable to a value other

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -76,8 +76,11 @@
    }
 
    # on Windows, we create a stub library that links to us so that
-   # older binaries (like rstan) can still load
-   if (.Platform$OS.type == "windows") {
+   # older binaries (like rstan) can still load. this is only relevant
+   # when TBB is available: the stub cannot link without it, and old
+   # TBB-using binaries could not run against a TBB-less RcppParallel
+   # regardless
+   if (.Platform$OS.type == "windows" && TBB_ENABLED) {
       tbbDll <- file.path(tbbDest, "tbb.dll")
       if (file.exists(tbbDll)) {
          writeLines("** tbb.dll already exists; skipping tbb stub library")

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -267,8 +267,10 @@ if (.Platform$OS.type == "windows") {
 define(PKG_LIBS = paste(pkgLibs, collapse = " "))
    
 # if we're going to build tbb from sources, check for cmake
+# (not required on Windows, where the bundled TBB is never built;
+# without an Rtools TBB, the tinythread fallback is used instead)
 define(CMAKE = "")
-if (is.na(tbbLib)) {
+if (is.na(tbbLib) && .Platform$OS.type != "windows") {
    
    cmake <- local({
       


### PR DESCRIPTION
On Windows systems whose Rtools does not provide TBB (R < 4.2.0, per 6.0.0's NEWS), two code paths broke installation from source:

1. **configure required cmake whenever `TBB_LIB` was empty** -- but the bundled TBB is never built on Windows (the dispatch prints "building RcppParallel without tbb backend" instead), so the requirement is spurious there. Configure would die with "cmake was not found" on machines without cmake.
2. **The tbb stub library was built unconditionally on Windows** -- but `tbb-compat.cpp` references `tbb::detail::r1::observe`, and with TBB disabled `PKG_LIBS` is just `-lssp`, so the stub DLL link failed and `stop()` killed the install. The stub is also useless in that configuration: `RcppParallel.dll` exports no TBB symbols, so pre-built TBB-using binaries could not run against it regardless of load resolution.

Skip the cmake requirement on Windows, and gate the stub build on `TBB_ENABLED` (available from `tbb-autodetected.R`, already sourced at the install-libs phase).

Relevant given `DESCRIPTION` declares `Depends: R (>= 3.6.0)`. Logic-only change; not exercised on CRAN's builders (which all have TBB-providing Rtools).