### PR TITLE
ship versioned tbb libraries on linux again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # RcppParallel (development version)
 
+* On Linux, the bundled TBB libraries are once again installed with versioned
+  names (e.g. `libtbb.so.2`) plus an unversioned `libtbb.so` symlink, matching
+  the layout shipped by RcppParallel 5.1.11 and earlier. The oneTBB cmake build
+  produces only unversioned libraries on Linux, so binaries compiled against
+  those releases (which recorded a load-time dependency on `libtbb.so.2`) would
+  otherwise fail to load after an upgrade with "libtbb.so.2: cannot open shared
+  object file".
+
 * Fixed installation on Windows toolchains providing an older (non-oneTBB)
   copy of TBB, e.g. Rtools42: the tbb stub library is now built by
   re-exporting the static TBB library, rather than wrapping the oneTBB

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -178,8 +178,9 @@ versionBundledTbbLibraries <- function(tbbDest) {
       if (file.exists(versioned))
          next
 
-      writeLines(sprintf("** versioning tbb library '%s' -> '%s'",
-                         basename(lib), basename(versioned)))
+      fmt <- "** versioning tbb library '%s' -> '%s'"
+      msg <- sprintf(fmt, basename(lib), basename(versioned))
+      writeLines(msg)
 
       # 'libtbb.so' -> 'libtbb.so.2', then re-create 'libtbb.so' as a
       # relative symlink pointing back at the versioned library

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -167,39 +167,73 @@ versionBundledTbbLibraries <- function(tbbDest) {
    suffix <- "2"
 
    libs <- list.files(tbbDest, pattern = "^libtbb.*\\.so$", full.names = TRUE)
-   for (lib in libs) {
+   for (lib in libs)
+      versionBundledTbbLibrary(lib, paste0(lib, ".", suffix))
 
-      # leave symlinks and linker scripts (i.e. an already-versioned layout)
-      # untouched; only real, unversioned libraries need renaming
-      if (nzchar(Sys.readlink(lib)))
-         next
+}
 
-      versioned <- paste0(lib, ".", suffix)
-      if (file.exists(versioned))
-         next
+# Version a single bundled TBB library. Failing to produce the versioned
+# layout is an error: a partial or silently-skipped layout would only
+# resurface later as load failures in downstream binaries, so fail the
+# install loudly instead.
+versionBundledTbbLibrary <- function(lib, versioned) {
 
-      fmt <- "** versioning tbb library '%s' -> '%s'"
-      msg <- sprintf(fmt, basename(lib), basename(versioned))
-      writeLines(msg)
+   # leave symlinks (i.e. an already-versioned layout) untouched; only real,
+   # unversioned libraries need renaming
+   if (nzchar(Sys.readlink(lib)))
+      return(invisible(FALSE))
 
-      # 'libtbb.so' -> 'libtbb.so.2', then re-create 'libtbb.so' as a
-      # relative symlink pointing back at the versioned library
-      file.rename(lib, versioned)
-      linked <- tryCatch(
-         file.symlink(basename(versioned), lib),
-         warning = function(w) FALSE
-      )
+   # only version actual ELF libraries; this leaves linker scripts alone
+   # (in old-style layouts, 'libtbb.so' is an INPUT() script and the real
+   # library already sits at 'libtbb.so.2'), while still replacing a stale
+   # 'libtbb.so.2' left behind by a previous installation
+   if (!isElfFile(lib))
+      return(invisible(FALSE))
 
-      # if the symlink couldn't be created (e.g. a filesystem without symlink
-      # support), fall back to a plain copy so that 'libtbb.so' still exists --
-      # RcppParallel's own shared object records a load-time dependency on it
-      if (!isTRUE(linked)) {
-         writeLines("** could not create symlink; copying instead")
-         file.copy(versioned, lib, overwrite = TRUE)
-      }
+   fmt <- "** versioning tbb library '%s' -> '%s'"
+   msg <- sprintf(fmt, basename(lib), basename(versioned))
+   writeLines(msg)
 
+   # 'libtbb.so' -> 'libtbb.so.2'
+   if (!isTRUE(file.rename(lib, versioned))) {
+      fmt <- "couldn't rename '%s' to '%s'"
+      stop(sprintf(fmt, lib, versioned))
    }
 
+   # re-create 'libtbb.so' as a relative symlink pointing back at the
+   # versioned library
+   linked <- tryCatch(
+      file.symlink(basename(versioned), lib),
+      warning = function(w) FALSE
+   )
+   if (isTRUE(linked))
+      return(invisible(TRUE))
+
+   # if the symlink couldn't be created (e.g. a filesystem without symlink
+   # support), fall back to a plain copy so that 'libtbb.so' still exists.
+   # the library has already been renamed at this point, so a failed copy
+   # would leave no 'libtbb.so' at all; fail loudly rather than complete a
+   # broken install
+   writeLines("** couldn't create symlink; copying instead")
+   copied <- tryCatch(
+      file.copy(versioned, lib, overwrite = TRUE),
+      warning = function(w) FALSE
+   )
+   if (!isTRUE(copied)) {
+      fmt <- "couldn't copy '%s' to '%s'"
+      stop(sprintf(fmt, versioned, lib))
+   }
+
+   invisible(TRUE)
+
+}
+
+isElfFile <- function(path) {
+   header <- tryCatch(
+      readBin(path, "raw", n = 4L),
+      condition = function(cnd) raw()
+   )
+   identical(header, charToRaw("\x7fELF"))
 }
 
 # Report which TBB libraries are about to be installed, and from where.

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -50,6 +50,11 @@
          system2("cp", c("-P", shQuote(tbbLib), shQuote(tbbDest)))
       }
 
+      # restore the versioned library layout shipped by RcppParallel 5.1.11
+      # and earlier (a real 'libtbb.so.2' plus a 'libtbb.so' symlink)
+      if (Sys.info()[["sysname"]] == "Linux")
+         versionBundledTbbLibraries(tbbDest)
+
    } else {
 
       # using system tbb
@@ -142,6 +147,46 @@ buildTbbStub <- function(tbbDest) {
    }
 
    file.copy("tbb-compat/tbb.dll", file.path(tbbDest, "tbb.dll"))
+
+}
+
+# Give the bundled TBB libraries the versioned '.so.<N>' names, plus an
+# unversioned 'libtbb.so' compatibility symlink, that RcppParallel shipped on
+# Linux through 5.1.11. That layout came from Intel TBB's make-based build,
+# which set the library SONAME from TBB_COMPATIBLE_INTERFACE_VERSION (2) and
+# emitted 'libtbb.so' as a linker script pointing at 'libtbb.so.2'. The
+# oneTBB cmake build only versions its output on Windows, so on Linux it
+# produces unversioned libraries (e.g. 'libtbb.so' with SONAME 'libtbb.so')
+# instead. Binaries compiled against RcppParallel <= 5.1.11 recorded a
+# load-time dependency on 'libtbb.so.2'; without this, they fail to load after
+# an upgrade with "libtbb.so.2: cannot open shared object file".
+versionBundledTbbLibraries <- function(tbbDest) {
+
+   # downstream binaries look for exactly '.so.2', matching the SONAME suffix
+   # the old TBB build derived from TBB_COMPATIBLE_INTERFACE_VERSION
+   suffix <- "2"
+
+   libs <- list.files(tbbDest, pattern = "^libtbb.*\\.so$", full.names = TRUE)
+   for (lib in libs) {
+
+      # leave symlinks and linker scripts (i.e. an already-versioned layout)
+      # untouched; only real, unversioned libraries need renaming
+      if (nzchar(Sys.readlink(lib)))
+         next
+
+      versioned <- paste0(lib, ".", suffix)
+      if (file.exists(versioned))
+         next
+
+      writeLines(sprintf("** versioning tbb library '%s' -> '%s'",
+                         basename(lib), basename(versioned)))
+
+      # 'libtbb.so' -> 'libtbb.so.2', then re-create 'libtbb.so' as a
+      # relative symlink pointing back at the versioned library
+      file.rename(lib, versioned)
+      file.symlink(basename(versioned), lib)
+
+   }
 
 }
 

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -185,7 +185,18 @@ versionBundledTbbLibraries <- function(tbbDest) {
       # 'libtbb.so' -> 'libtbb.so.2', then re-create 'libtbb.so' as a
       # relative symlink pointing back at the versioned library
       file.rename(lib, versioned)
-      file.symlink(basename(versioned), lib)
+      linked <- tryCatch(
+         file.symlink(basename(versioned), lib),
+         warning = function(w) FALSE
+      )
+
+      # if the symlink couldn't be created (e.g. a filesystem without symlink
+      # support), fall back to a plain copy so that 'libtbb.so' still exists --
+      # RcppParallel's own shared object records a load-time dependency on it
+      if (!isTRUE(linked)) {
+         writeLines("** could not create symlink; copying instead")
+         file.copy(versioned, lib, overwrite = TRUE)
+      }
 
    }
 


### PR DESCRIPTION
## Problem

On Linux, RcppParallel 6.0.x installs **unversioned** TBB libraries — `libtbb.so` with SONAME `libtbb.so`, and no `libtbb.so.2`. This is a regression from 5.1.11 and earlier, which shipped a real `libtbb.so.2` plus a `libtbb.so` redirect.

The cause is the oneTBB cmake build: it only versions its output under `if (WIN32)` (`OUTPUT_NAME "tbb${TBB_BINARY_VERSION}"`) and sets no `SOVERSION`, so Linux/macOS get the bare target name. 5.1.11's versioned layout was never something RcppParallel did explicitly — it came from Intel TBB's make-based build (`build/linux.inc` set the SONAME suffix from `TBB_COMPATIBLE_INTERFACE_VERSION`, i.e. `2`, and `Makefile.tbb` emitted `libtbb.so` as an `INPUT(libtbb.so.2)` linker script).

Binaries compiled against RcppParallel ≤ 5.1.11 recorded a load-time dependency on `libtbb.so.2`. After an upgrade to 6.0.x that file no longer exists, so they fail to load:

```
unable to load shared object '.../foo.so':
  libtbb.so.2: cannot open shared object file: No such file or directory
```

This was reported by the CRAN maintainer during revdep checking on Fedora.

## Fix

For the **bundled** TBB on **Linux** only, after copying the libraries, rename each real unversioned `libtbb*.so` to `libtbb*.so.2` and re-create `libtbb*.so` as a relative symlink pointing back at it. This restores the historical layout so legacy `NEEDED libtbb.so.2` dependencies resolve again.

- Scoped to the bundled build; the external/system-TBB path is untouched (that library keeps its own SONAME and lives on a stable system path).
- Idempotent: skips symlinks/linker scripts and any already-versioned file.
- A **symlink**, not a linker script: a linker script (`INPUT(...)`) works at link time but the dynamic loader can't parse it, so it would fail at runtime — and 6.0.x's `RcppParallel.so` itself has `NEEDED libtbb.so`.

## Verification

Rebuilt into a temporary library on Linux:

- Resulting layout is `libtbb.so.2` (real) + `libtbb.so -> libtbb.so.2` for `tbb`, `tbbmalloc`, and `tbbmalloc_proxy`.
- Package loads; `setThreadOptions()` works; `tbbLibraryPath("tbb")` returns the `.so.2`.
- `RcppParallel.so`'s own `NEEDED libtbb.so` resolves via the new symlink.
- A synthesized binary with a genuine `NEEDED libtbb.so.2` (mimicking a 5.1.11-built revdep) now resolves the file against the new install — the load error is gone.

## Note

Giving the new-ABI oneTBB the legacy `.so.2` name means an old binary now *loads* it and could fault on a removed symbol rather than getting a clean file-not-found; that is what the existing compatibility headers/symbols are for, and a rebuild remains the real fix. This change restores pre-6.0 behavior and stops the file-level breakage.