### PR TITLE
enable tbb by default on musl-based linux (e.g. alpine)

### DIFF
--- a/inst/include/RcppParallel.h
+++ b/inst/include/RcppParallel.h
@@ -9,8 +9,11 @@
 // (NOTE: Windows TBB is temporarily opt-in for packages for
 // compatibility with CRAN packages not previously configured
 // to link to TBB in Makevars.win)
+// NOTE: match Linux via __linux__ rather than __gnu_linux__; the latter is
+// only defined by glibc toolchains, which left TBB disabled by default on
+// musl-based systems such as Alpine Linux (https://github.com/RcppCore/RcppParallel/issues/231)
 #ifndef RCPP_PARALLEL_USE_TBB
-# if defined(__APPLE__) || defined(__gnu_linux__) || (defined(__sun) && defined(__SVR4) && !defined(__sparc))
+# if defined(__APPLE__) || defined(__linux__) || (defined(__sun) && defined(__SVR4) && !defined(__sparc))
 #  define RCPP_PARALLEL_USE_TBB 1
 # else
 #  define RCPP_PARALLEL_USE_TBB 0


### PR DESCRIPTION
Fixes #231.

`RcppParallel.h` gated the default `RCPP_PARALLEL_USE_TBB` on `__gnu_linux__`, a **glibc-only** predefined macro. musl-based systems such as Alpine define `__linux__` but not `__gnu_linux__`, so the default fell through to `0` — disabling TBB for any downstream package that doesn't pass `-DRCPP_PARALLEL_USE_TBB` explicitly (i.e. doesn't use `RcppParallel::CxxFlags()` in its Makevars), even when RcppParallel itself was built with a working TBB.

This matches packages like FLSSS and evesim still failing on Alpine in #231 despite 6.0.0 emitting the flag from `CxxFlags()` (which fixed only the packages that *do* use it, e.g. bgms).

## Fix

Match Linux via `__linux__`, which covers both glibc and musl:

```c
# if defined(__APPLE__) || defined(__linux__) || (defined(__sun) && defined(__SVR4) && !defined(__sparc))
```

Consistent with the bundled TBB sources, which use `__linux__` broadly and only guard on `__GLIBC__` where glibc-specific behavior is required. On glibc Linux the header already defaulted to `1` regardless of build-time TBB status, so this introduces no new mismatch — it just brings musl in line with every other Linux.
