### PR TITLE
add tests for isProcessForkedChild() and archSystemFile()

### DIFF
--- a/tests/test-arch-system-file.R
+++ b/tests/test-arch-system-file.R
@@ -8,14 +8,25 @@ RcppParallel:::test_init()
 
 arch <- .Platform$r_arch
 
+# compare two file paths for equality. system.file() returns "" when a path is
+# not found, so preserve that sentinel; otherwise normalize both sides, since
+# strings that differ only in separators, case, or symlinks can still denote
+# the same file (and normalizePath("") would resolve to the working directory).
+samePath <- function(a, b) {
+   norm <- function(p) {
+      if (nzchar(p)) normalizePath(p, winslash = "/", mustWork = FALSE) else p
+   }
+   identical(norm(a), norm(b))
+}
+
 # with no arch subdirectory (the usual case off Windows), archSystemFile()
 # should be equivalent to a plain system.file() call
 if (!nzchar(arch)) {
-   assert(identical(
+   assert(samePath(
       archSystemFile("include"),
       system.file("include", package = "RcppParallel")
    ))
-   assert(identical(
+   assert(samePath(
       archSystemFile("include", "RcppParallel.h"),
       system.file("include/RcppParallel.h", package = "RcppParallel")
    ))
@@ -28,8 +39,8 @@ expected <- function(dir, name = NULL) {
    system.file(paste(parts, collapse = "/"), package = "RcppParallel")
 }
 
-assert(identical(archSystemFile("lib"), expected("lib")))
-assert(identical(archSystemFile("lib", "libtbb.so"), expected("lib", "libtbb.so")))
+assert(samePath(archSystemFile("lib"), expected("lib")))
+assert(samePath(archSystemFile("lib", "libtbb.so"), expected("lib", "libtbb.so")))
 
 # a real, shipped resource resolves to an existing path
 header <- archSystemFile("include", "RcppParallel.h")

--- a/tests/test-arch-system-file.R
+++ b/tests/test-arch-system-file.R
@@ -1,9 +1,11 @@
 # Unit tests for archSystemFile(), the arch-aware wrapper around system.file()
-# introduced when systemFile() was renamed (see #251, #252). It injects the
-# architecture-specific subdirectory (.Platform$r_arch) used on Windows, e.g.
-# archSystemFile("lib") -> 'lib/x64', while behaving like system.file()
-# elsewhere. Note that this subdirectory only ever holds compiled libraries
-# ('lib', 'libs'); headers and other resources are never installed under it.
+# introduced when systemFile() was renamed (see #251, #252). When R is built
+# multi-arch -- typically Windows, but also possible on Linux and macOS -- it
+# installs compiled libraries under an architecture-specific subdirectory named
+# by .Platform$r_arch, e.g. 'libs/x64'. archSystemFile() injects that subdir,
+# and behaves like system.file() when r_arch is unset. Note the subdir only
+# ever holds compiled libraries ('lib', 'libs'); headers and other resources
+# are never installed under it.
 
 RcppParallel:::test_init()
 
@@ -40,8 +42,8 @@ assert(samePath(archSystemFile("lib"), expected("lib")))
 assert(samePath(archSystemFile("lib", "libtbb.so"), expected("lib", "libtbb.so")))
 
 # the package's own compiled code is installed under 'libs' (or 'libs/<arch>'
-# on Windows) -- exactly the arch-aware lookup archSystemFile() exists for --
-# so it must resolve to an existing directory on every platform
+# under a multi-arch R) -- exactly the arch-aware lookup archSystemFile()
+# exists for -- so it must resolve to an existing directory on every platform
 libs <- archSystemFile("libs")
 assert(nzchar(libs))
 assert(dir.exists(libs))

--- a/tests/test-arch-system-file.R
+++ b/tests/test-arch-system-file.R
@@ -2,7 +2,8 @@
 # introduced when systemFile() was renamed (see #251, #252). It injects the
 # architecture-specific subdirectory (.Platform$r_arch) used on Windows, e.g.
 # archSystemFile("lib") -> 'lib/x64', while behaving like system.file()
-# elsewhere.
+# elsewhere. Note that this subdirectory only ever holds compiled libraries
+# ('lib', 'libs'); headers and other resources are never installed under it.
 
 RcppParallel:::test_init()
 
@@ -23,12 +24,8 @@ samePath <- function(a, b) {
 # should be equivalent to a plain system.file() call
 if (!nzchar(arch)) {
    assert(samePath(
-      archSystemFile("include"),
-      system.file("include", package = "RcppParallel")
-   ))
-   assert(samePath(
-      archSystemFile("include", "RcppParallel.h"),
-      system.file("include/RcppParallel.h", package = "RcppParallel")
+      archSystemFile("libs"),
+      system.file("libs", package = "RcppParallel")
    ))
 }
 
@@ -42,7 +39,9 @@ expected <- function(dir, name = NULL) {
 assert(samePath(archSystemFile("lib"), expected("lib")))
 assert(samePath(archSystemFile("lib", "libtbb.so"), expected("lib", "libtbb.so")))
 
-# a real, shipped resource resolves to an existing path
-header <- archSystemFile("include", "RcppParallel.h")
-assert(nzchar(header))
-assert(file.exists(header))
+# the package's own compiled code is installed under 'libs' (or 'libs/<arch>'
+# on Windows) -- exactly the arch-aware lookup archSystemFile() exists for --
+# so it must resolve to an existing directory on every platform
+libs <- archSystemFile("libs")
+assert(nzchar(libs))
+assert(dir.exists(libs))

--- a/tests/test-arch-system-file.R
+++ b/tests/test-arch-system-file.R
@@ -1,0 +1,37 @@
+# Unit tests for archSystemFile(), the arch-aware wrapper around system.file()
+# introduced when systemFile() was renamed (see #251, #252). It injects the
+# architecture-specific subdirectory (.Platform$r_arch) used on Windows, e.g.
+# archSystemFile("lib") -> 'lib/x64', while behaving like system.file()
+# elsewhere.
+
+RcppParallel:::test_init()
+
+arch <- .Platform$r_arch
+
+# with no arch subdirectory (the usual case off Windows), archSystemFile()
+# should be equivalent to a plain system.file() call
+if (!nzchar(arch)) {
+   assert(identical(
+      archSystemFile("include"),
+      system.file("include", package = "RcppParallel")
+   ))
+   assert(identical(
+      archSystemFile("include", "RcppParallel.h"),
+      system.file("include/RcppParallel.h", package = "RcppParallel")
+   ))
+}
+
+# the composed relative path must match what system.file() is handed: dir,
+# then the arch subdir when set, then the optional name -- joined with '/'
+expected <- function(dir, name = NULL) {
+   parts <- c(dir, if (nzchar(arch)) arch, name)
+   system.file(paste(parts, collapse = "/"), package = "RcppParallel")
+}
+
+assert(identical(archSystemFile("lib"), expected("lib")))
+assert(identical(archSystemFile("lib", "libtbb.so"), expected("lib", "libtbb.so")))
+
+# a real, shipped resource resolves to an existing path
+header <- archSystemFile("include", "RcppParallel.h")
+assert(nzchar(header))
+assert(file.exists(header))

--- a/tests/test-fork.R
+++ b/tests/test-fork.R
@@ -1,0 +1,26 @@
+# Unit tests for isProcessForkedChild().
+#
+# The contract: it returns FALSE in the process where RcppParallel was loaded,
+# and TRUE in a fork() of that process (e.g. a parallel::mclapply worker). On
+# Windows there is no fork(), so it always returns FALSE.
+
+RcppParallel:::test_init()
+
+# in the parent process, we are never a forked child
+assert(isProcessForkedChild() == FALSE)
+
+# parallel::mclapply uses fork() on unix, so its workers must report TRUE.
+# on Windows there is no fork() (mclapply falls back to serial), so skip: the
+# workers there run in the parent process and would correctly report FALSE.
+if (!is_windows()) {
+
+   results <- parallel::mclapply(1:2, function(i) {
+      RcppParallel::isProcessForkedChild()
+   }, mc.cores = 2L)
+
+   assert(all(vapply(results, isTRUE, logical(1L))))
+
+}
+
+# forking must not disturb the parent's own view of itself
+assert(isProcessForkedChild() == FALSE)


### PR DESCRIPTION
Adds automated coverage for two additions since 5.1.11 that previously had no tests.

## `tests/test-fork.R`
Covers `isProcessForkedChild()` (#243, #244):
- returns `FALSE` in the parent process
- returns `TRUE` inside `parallel::mclapply` workers (skipped on Windows, which has no `fork()`)
- the parent's own view is unchanged after forking

## `tests/test-arch-system-file.R`
Covers `archSystemFile()` (#251, #252):
- equivalent to `system.file()` when there is no arch subdirectory
- composes the arch-specific subdirectory when `.Platform$r_arch` is set
- a real shipped resource (`include/RcppParallel.h`) resolves to an existing path

Both follow the existing `tests/test-*.R` harness conventions (`test_init()` + `assert()`), so they run under `R CMD check`.