### PR TITLE
forward ccache to cmake via CMAKE_<LANG>_COMPILER_LAUNCHER

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # RcppParallel (development version)
 
+* Fixed an issue where building the bundled oneTBB could fail when `CXX`
+  (or `CC`) was configured with a leading compiler launcher such as `ccache`
+  (e.g. `CXX = "ccache g++"`). The launcher is now forwarded to cmake via
+  `CMAKE_<LANG>_COMPILER_LAUNCHER` instead of being mistaken for the compiler
+  itself.
+
 
 # RcppParallel 6.1.1
 

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -325,6 +325,13 @@ useBundledTbb <- function() {
    buildType <- Sys.getenv("CMAKE_BUILD_TYPE", unset = "Release")
    verbose <- Sys.getenv("VERBOSE", unset = "0")
 
+   # pull any leading compiler launcher (e.g. ccache) out of CC / CXX before
+   # splitting, so it can be forwarded to CMake the way CMake expects it (see
+   # extractCompilerLauncher); otherwise ccache would be treated as the
+   # compiler itself, breaking CMake's compiler / assembler probes
+   ccLauncher  <- extractCompilerLauncher("CC")
+   cxxLauncher <- extractCompilerLauncher("CXX")
+
    splitCompilerVar("CC", "CFLAGS")
    splitCompilerVar("CXX", "CXXFLAGS")
 
@@ -341,6 +348,10 @@ useBundledTbb <- function() {
    cmakeFlags <- c(
       forwardEnvVar("CC", "CMAKE_C_COMPILER"),
       forwardEnvVar("CXX", "CMAKE_CXX_COMPILER"),
+      if (!is.na(ccLauncher))
+         sprintf("-DCMAKE_C_COMPILER_LAUNCHER=%s", ccLauncher),
+      if (!is.na(cxxLauncher))
+         sprintf("-DCMAKE_CXX_COMPILER_LAUNCHER=%s", cxxLauncher),
       forwardEnvVar("CFLAGS", "CMAKE_C_FLAGS"),
       forwardEnvVar("CXXFLAGS", "CMAKE_CXX_FLAGS"),
       forwardEnvVar("CMAKE_BUILD_TYPE", "CMAKE_BUILD_TYPE"),
@@ -431,6 +442,33 @@ setenv <- function(key, value) {
    args <- list(paste(value, collapse = " "))
    names(args) <- key
    do.call(Sys.setenv, args)
+}
+
+
+# Compiler launchers such as ccache are commonly injected by prefixing the
+# compiler (e.g. CXX='ccache g++'). CMake models these via the separate
+# CMAKE_<LANG>_COMPILER_LAUNCHER variable rather than as part of the compiler
+# command, so detect a leading launcher, strip it from the compiler variable,
+# and return it for forwarding. Returns NA when no launcher is present.
+extractCompilerLauncher <- function(compilerVar) {
+
+   compiler <- Sys.getenv(compilerVar, unset = NA)
+   if (is.na(compiler))
+      return(NA_character_)
+
+   tokens <- scan(text = compiler, what = character(), quiet = TRUE)
+   if (length(tokens) == 0L)
+      return(NA_character_)
+
+   launcher <- tokens[[1L]]
+   name <- sub("[.]exe$", "", basename(launcher), ignore.case = TRUE)
+   if (!name %in% c("ccache", "sccache"))
+      return(NA_character_)
+
+   # drop the launcher, leaving the real compiler (and any flags) behind
+   setenv(compilerVar, tokens[-1L])
+   launcher
+
 }
 
 

--- a/tests/test-install-libs.R
+++ b/tests/test-install-libs.R
@@ -40,6 +40,7 @@ if (length(marker))
 env <- new.env(parent = globalenv())
 eval(parse(text = paste(lines, collapse = "\n")), envir = env)
 splitCompilerVar <- get("splitCompilerVar", envir = env)
+extractCompilerLauncher <- get("extractCompilerLauncher", envir = env)
 patchTbbMachineHeader <- get("patchTbbMachineHeader", envir = env)
 
 # minimal assertion harness
@@ -112,6 +113,49 @@ withEnv(c(TEST_CXX = "   ", TEST_CXXFLAGS = "-Wall"), {
 Sys.unsetenv("TEST_CXX_UNSET")
 check(identical(splitCompilerVar("TEST_CXX_UNSET", "TEST_CXXFLAGS"), FALSE),
    "unset compiler variable returns FALSE")
+
+# a leading compiler launcher (ccache) must be split off from the compiler so
+# CMake can receive it via CMAKE_<LANG>_COMPILER_LAUNCHER. Left in place, CMake
+# would treat 'ccache' as the compiler and run 'ccache ... -Wa,-v' during its
+# assembler probe, which ccache rejects with "invalid option -- 'W'".
+withEnv(c(TEST_CXX = "ccache g++"), {
+   launcher <- extractCompilerLauncher("TEST_CXX")
+   check(identical(launcher, "ccache"), "ccache launcher is extracted")
+   check(identical(Sys.getenv("TEST_CXX"), "g++"),
+      "ccache launcher is stripped from the compiler")
+})
+
+# the launcher may be a full path and carry trailing compiler flags; only the
+# launcher token is removed, leaving the compiler and its flags intact
+withEnv(c(TEST_CXX = "/usr/bin/ccache g++ -std=c++17"), {
+   launcher <- extractCompilerLauncher("TEST_CXX")
+   check(identical(launcher, "/usr/bin/ccache"),
+      "ccache launcher path is extracted")
+   check(identical(Sys.getenv("TEST_CXX"), "g++ -std=c++17"),
+      "compiler and flags survive launcher extraction")
+})
+
+# sccache is recognized as a launcher too
+withEnv(c(TEST_CXX = "sccache clang++"), {
+   launcher <- extractCompilerLauncher("TEST_CXX")
+   check(identical(launcher, "sccache"), "sccache launcher is extracted")
+   check(identical(Sys.getenv("TEST_CXX"), "clang++"),
+      "sccache launcher is stripped from the compiler")
+})
+
+# a plain compiler has no launcher: return NA and leave the variable untouched
+withEnv(c(TEST_CXX = "g++ -O2"), {
+   launcher <- extractCompilerLauncher("TEST_CXX")
+   check(identical(launcher, NA_character_),
+      "plain compiler yields no launcher")
+   check(identical(Sys.getenv("TEST_CXX"), "g++ -O2"),
+      "plain compiler is left unmodified")
+})
+
+# an unset compiler variable is a no-op that reports NA
+Sys.unsetenv("TEST_CXX_UNSET")
+check(identical(extractCompilerLauncher("TEST_CXX_UNSET"), NA_character_),
+   "unset compiler variable yields no launcher")
 
 # the mingw cpuid guard should be applied exactly once to a header with the
 # expected form, and applying it again should leave the header untouched


### PR DESCRIPTION
## Problem

When R is configured with a compiler launcher baked into `CXX` (or `CC`) -- e.g. `CXX = "ccache g++"` -- building the bundled oneTBB fails during cmake configuration with:

```
CMake Error at cmake/compilers/GNU.cmake:65 (math):
  math cannot parse the expression: "/usr/bin/ccache: invalid option -- 'W' *
  1000 + /usr/bin/ccache: invalid option -- 'W'": syntax error, ...
```

### Root cause

`splitCompilerVar()` in `src/install.libs.R` treats the *first* token of `CXX` as the compiler, so `CXX = "ccache g++"` was forwarded to cmake as `CMAKE_CXX_COMPILER=ccache` with `g++` demoted into `CMAKE_CXX_FLAGS`. oneTBB's `GNU.cmake` then probes the assembler with `${CMAKE_CXX_COMPILER} ... -Wa,-v`, i.e. `ccache ... -Wa,-v`. ccache rejects `-W` (`invalid option -- 'W'`), the version regex fails to match, and the leftover error text is fed to cmake's `math()`, which aborts the build.

## Fix

CMake models compiler launchers via the dedicated `CMAKE_<LANG>_COMPILER_LAUNCHER` variable, not as part of the compiler command. This PR adds `extractCompilerLauncher()`, which pulls a leading `ccache`/`sccache` launcher (path- and `.exe`-tolerant) out of `CC`/`CXX` before splitting, and forwards it via `-DCMAKE_C_COMPILER_LAUNCHER=` / `-DCMAKE_CXX_COMPILER_LAUNCHER=`. The real compiler is left in place, so cmake's compiler/assembler probes run against it as intended, while ccache still wraps the actual compilation.

## Tests

Adds cases to `tests/test-install-libs.R` covering launcher extraction (`ccache`, path-qualified `ccache` with trailing flags, `sccache`), and the no-op paths (plain compiler, unset variable).
